### PR TITLE
Add `eot_token` property to gpt-j

### DIFF
--- a/lm_eval/models/gptj.py
+++ b/lm_eval/models/gptj.py
@@ -40,6 +40,10 @@ class GPTJLM(BaseLM):
         #     self.gptj = nn.DataParallel(self.gptj)
 
     @property
+    def eot_token(self):
+        return self.tokenizer.eos_token
+
+    @property
     def eot_token_id(self):
         # we use EOT because end of *text* is more accurate for what we're doing than end of *sentence*
         return self.tokenizer.eos_token_id


### PR DESCRIPTION
Missing `eot_token` property caused runtime error.