### PR TITLE
Remove stopping_criteria and set max_generation_length to 64

### DIFF
--- a/lm_eval/tasks/gem_xsum.py
+++ b/lm_eval/tasks/gem_xsum.py
@@ -1,5 +1,6 @@
+
 """
-Don’t Give Me the Details, Just the Summary! Topic-Aware Convolutional Neural Networks for Extreme Summarization
+Don't Give Me the Details, Just the Summary! Topic-Aware Convolutional Neural Networks for Extreme Summarization
 https://arxiv.org/pdf/1808.08745.pdf
 
 The dataset is for the task of abstractive summarization in its extreme form, its about summarizing a document in a single sentence. It introduces extreme summarization, a new single-document summarization task which does not favor extractive strategies and calls for an abstractive modeling approach. The idea is to create a short, one-sentence news summary answering the question "What is the article about?". 
@@ -58,6 +59,9 @@ class GEMXSUMBase(PromptSourceTask):
     def test_docs(self):
         if self.has_test_docs():
             return self.dataset["test"]
+
+    def max_generation_length(self):
+            return 64
 
 class GEMXSUM(GEMXSUMBase):
     '''this is for train/validation/test'''


### PR DESCRIPTION
I removed stopping_criteria  and set max_generation_length to 64 so that the models will generate the prediction until either eos or 64th tokens.

For GEN/xsum, the summary is supposed to be one sentence long. If we don't set max_generation_length, the model keeps generating the sentences. So, probably it's best to max_generation_length to 64, which is enough for even a long sentence.