### PR TITLE
Add progress bar to track few-shot context and request building

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -194,7 +194,7 @@ def evaluate(
             if description_dict and task_prompt_name in description_dict
             else ""
         )
-        # Building fewshot contexts for task_name and constructing request.t
+
         print(f"Constructing '{task_prompt_name}' contexts and requests")
         pbar_limit = len(task_docs) if not limit else limit
         for doc_id, (original_doc_id, doc) in enumerate(

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -9,6 +9,7 @@ import lm_eval.tasks
 import lm_eval.base
 import promptsource
 import numpy as np
+from tqdm import tqdm
 
 from promptsource.templates import DatasetTemplates
 from lm_eval.utils import positional_deprecated, run_task_tests, set_seed
@@ -193,9 +194,11 @@ def evaluate(
             if description_dict and task_prompt_name in description_dict
             else ""
         )
-
+        # Building fewshot contexts for task_name and constructing request.t
+        print(f"Constructing '{task_prompt_name}' contexts and requests")
+        pbar_limit = len(task_docs) if not limit else limit
         for doc_id, (original_doc_id, doc) in enumerate(
-            itertools.islice(task_docs, 0, limit)
+            tqdm(itertools.islice(task_docs, 0, limit), total=pbar_limit)
         ):
             if task.invalid_doc_for_prompt(doc):
                 continue


### PR DESCRIPTION
During complete task evaluation, constructing few-shot contexts with logging info and model requests can take a non-trivial amount of time. Currently, users have no idea that this is going on. This PR adds a display for progress tracking during this stage of evaluation.