### PR TITLE
Add `gsarti/flores101` tasks

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -1131,7 +1131,7 @@ class PerplexityTask(Task, abc.ABC):
     def doc_to_target(self, doc):
         """NOTE: This won't work for most HF datasets.
 
-        Over-ride this function per t
+        Over-ride this function per task.
         """
         return doc
 

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -1123,7 +1123,7 @@ class PerplexityTask(Task, abc.ABC):
     def doc_to_target(self, doc):
         """NOTE: This won't work for most HF datasets.
 
-        Over-ride this function per task.
+        Over-ride this function per t
         """
         return doc
 
@@ -1161,8 +1161,6 @@ class PerplexityTask(Task, abc.ABC):
 
     def get_logging_info(self):
         return {
-            "dataset_path": self.DATASET_PATH,
-            "dataset_name": self.DATASET_NAME,
             "prompt_name": None,
         }
 

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -1,0 +1,166 @@
+"""
+The FLORES-101 Evaluation Benchmark
+for Low-Resource and Multilingual Machine Translation
+https://arxiv.org/pdf/2106.03193.pdf
+
+HuggingFace Dataset: https://huggingface.co/datasets/gsarti/flores_101
+"""
+from lm_eval.base import PerplexityTask
+
+_CITATION = """
+@inproceedings{flores101,
+  title={The FLORES-101  Evaluation Benchmark for Low-Resource and Multilingual Machine Translation},
+  author={Goyal, Naman and Gao, Cynthia and Chaudhary, Vishrav and Chen, Peng-Jen and Wenzek, Guillaume and Ju, Da and Krishnan, Sanjana and Ranzato, Marc'Aurelio and Guzm\'{a}n, Francisco and Fan, Angela},
+  journal={arXiv preprint arXiv:2106.03193},
+  year={2021}
+}
+"""
+
+
+class Flores101(PerplexityTask):
+    VERSION = 0
+    DATASET_PATH = "gsarti/flores_101"
+
+    def __init__(
+        self,
+        data_dir=None,
+        cache_dir=None,
+        download_mode=None,
+        prompt=None,
+        save_examples=True,
+    ):
+        super().__init__(data_dir, cache_dir, download_mode)
+        self.save_examples = save_examples
+
+    def has_training_docs(self):
+        return False
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return False
+
+    def validation_docs(self):
+        return self.dataset["dev"]
+
+    def doc_to_target(self, doc):
+        """This is a null prompt task. We need to get the target from the doc."""
+        return doc["sentence"]
+
+
+LANG_SPLITS = [
+    "afr",
+    "amh",
+    "ara",
+    "hye",
+    "asm",
+    "ast",
+    "azj",
+    "bel",
+    "ben",
+    "bos",
+    "bul",
+    "mya",
+    "cat",
+    "ceb",
+    "zho_simpl",
+    "zho_trad",
+    "hrv",
+    "ces",
+    "dan",
+    "nld",
+    "eng",
+    "est",
+    "tgl",
+    "fin",
+    "fra",
+    "ful",
+    "glg",
+    "lug",
+    "kat",
+    "deu",
+    "ell",
+    "guj",
+    "hau",
+    "heb",
+    "hin",
+    "hun",
+    "isl",
+    "ibo",
+    "ind",
+    "gle",
+    "ita",
+    "jpn",
+    "jav",
+    "kea",
+    "kam",
+    "kan",
+    "kaz",
+    "khm",
+    "kor",
+    "kir",
+    "lao",
+    "lav",
+    "lin",
+    "lit",
+    "luo",
+    "ltz",
+    "mkd",
+    "msa",
+    "mal",
+    "mlt",
+    "mri",
+    "mar",
+    "mon",
+    "npi",
+    "nso",
+    "nob",
+    "nya",
+    "oci",
+    "ory",
+    "orm",
+    "pus",
+    "fas",
+    "pol",
+    "por",
+    "pan",
+    "ron",
+    "rus",
+    "srp",
+    "sna",
+    "snd",
+    "slk",
+    "slv",
+    "som",
+    "ckb",
+    "spa",
+    "swh",
+    "swe",
+    "tgk",
+    "tam",
+    "tel",
+    "tha",
+    "tur",
+    "ukr",
+    "umb",
+    "urd",
+    "uzb",
+    "vie",
+    "cym",
+    "wol",
+    "xho",
+    "yor",
+    "zul",
+]
+
+
+class Flores101Afr(Flores101):
+    VERSION = 0
+    DATASET_NAME = "afr"
+
+
+def construct_tasks():
+    tasks = {}
+    tasks[f"gsarti/flores_101_afr"] = Flores101Afr
+    return tasks

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -49,7 +49,7 @@ class Flores101(PerplexityTask):
         return doc["sentence"]
 
 
-LANG_SPLITS = [
+LANGS = [
     "afr",
     "amh",
     "ara",
@@ -155,12 +155,16 @@ LANG_SPLITS = [
 ]
 
 
-class Flores101Afr(Flores101):
-    VERSION = 0
-    DATASET_NAME = "afr"
+def make_class(lang):
+    class Flores101Lang(Flores101):
+        DATASET_NAME = lang
+
+    return Flores101Lang
 
 
 def construct_tasks():
     tasks = {}
-    tasks[f"gsarti/flores_101_afr"] = Flores101Afr
+    for lang in LANGS:
+        # Dynamically create a class for each language with a different `DATASET_NAME`
+        tasks[f"gsarti/flores_101_{lang}"] = make_class(lang)
     return tasks

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -29,7 +29,13 @@ class Flores101(PerplexityTask):
         prompt=None,
         save_examples=True,
     ):
-        super().__init__(data_dir, cache_dir, download_mode)
+        super().__init__(
+            data_dir,
+            cache_dir,
+            download_mode,
+            # True! We want to track the performance across different topics/domains
+            save_examples=save_examples,
+        )
         self.save_examples = save_examples
 
     def has_training_docs(self):
@@ -47,6 +53,15 @@ class Flores101(PerplexityTask):
     def doc_to_target(self, doc):
         """This is a null prompt task. We need to get the target from the doc."""
         return doc["sentence"]
+
+    def process_results(self, doc, results):
+        if self.save_examples:
+            out, log = super().process_results(doc, results)
+            log["topic"] = doc["topic"]
+            log["domain"] = doc["domain"]
+            return out, log
+        else:
+            return super().process_results(doc, results)
 
 
 LANGS = [

--- a/main.py
+++ b/main.py
@@ -122,6 +122,7 @@ def main():
             f,
             indent=2,
         )
+    print(evaluator.make_table(results))
     emissions_output_path = f"./outputs/emissions-{output_path}.csv"
     os.rename("emissions.csv", emissions_output_path)
 


### PR DESCRIPTION
[gsarti/flores_101](https://huggingface.co/datasets/gsarti/flores_101) is a dataset with 102 languages we will use for language modeling.

* Adds the 102 language subsets dynamically
* The prompt is null -- just the sentence itself -- as this dataset is only used for language modeling (LM).
* Therefore, this task doesn't actually interface with `promptsource`. (I don't see a good reason to add a no-opt prompt.)
* I have run gpt2 on `eng`, `afr`, `zul`.
* Updated `PerplexityTask` to work with our new evaluation pipeline
* Bug Fix: Add back the printing out of the metric table

On a small batch, the perplexity of `zul` is much higher than `eng`. `afr` is in the middle.
```
|        Task         |Prompt|Version|    Metric     |      Value      |   |Stderr|
|---------------------|------|------:|---------------|----------------:|---|------|
|gsarti/flores_101_zul|null  |      0|word_perplexity|216552120498.3945|   |      |
|gsarti/flores_101_zul|null  |       |byte_perplexity|          16.0288|   |      |
|gsarti/flores_101_zul|null  |       |bits_per_byte  |           4.0026|   |      |

|gsarti/flores_101_eng|null  |      0|word_perplexity|114.6932|   |      |
|gsarti/flores_101_eng|null  |       |byte_perplexity|  2.1966|   |      |
|gsarti/flores_101_eng|null  |       |bits_per_byte  |  1.1353|   |      |

|gsarti/flores_101_afr|null  |      0|word_perplexity|3033186.7456|   |      |
|gsarti/flores_101_afr|null  |       |byte_perplexity|     11.4120|   |      |
|gsarti/flores_101_afr|null  |       |bits_per_byte  |      3.5125|   |      |
```

