### PR TITLE
Using `logging` for examples instead of `json`

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -248,6 +248,7 @@ def evaluate(
     vals = collections.defaultdict(list)
 
     # unpack results and sort back in order and return control to Task
+    logger = logging.getLogger("examples")
     for (task_prompt_name, doc_id), per_doc_requests in process_res_queue.items():
         per_doc_requests.sort(key=lambda x: x[0])
         per_doc_results = [x[1] for x in per_doc_requests]
@@ -257,7 +258,7 @@ def evaluate(
         doc = docs[(task_prompt_name, doc_id)]
 
         output = task.process_results(doc, per_doc_results)
-        logger = logging.getLogger("examples")
+
         if task.save_examples:
             metrics, example = output
             example.update(fewshot_logging_info)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -248,7 +248,6 @@ def evaluate(
     vals = collections.defaultdict(list)
 
     # unpack results and sort back in order and return control to Task
-    examples = []
     for (task_prompt_name, doc_id), per_doc_requests in process_res_queue.items():
         per_doc_requests.sort(key=lambda x: x[0])
         per_doc_results = [x[1] for x in per_doc_requests]
@@ -258,19 +257,16 @@ def evaluate(
         doc = docs[(task_prompt_name, doc_id)]
 
         output = task.process_results(doc, per_doc_results)
+        logger = logging.getLogger("examples")
         if task.save_examples:
             metrics, example = output
             example.update(fewshot_logging_info)
             example.update(task.get_logging_info())
-            logger = logging.getLogger("examples")
             logger.info(json.dumps(example))
-            examples.append(example)
         else:
             metrics = output
             example = fewshot_logging_info
             example.update(task.get_logging_info())
-            examples.append(example)
-            logger = logging.getLogger("examples")
             logger.info(json.dumps(example))
 
         for metric, value in metrics.items():
@@ -311,7 +307,6 @@ def evaluate(
         "results": metric_results,
         "versions": dict(versions),
         # List of all prompt x doc examples with additional information in it.
-        "examples": examples,
         # Original results used for generating the table when running this file.
         "table_results": dict(results),
     }

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -10,6 +10,8 @@ from tqdm import tqdm
 
 from lm_eval.utils import positional_deprecated, run_task_tests, set_seed
 
+import logging, json
+
 
 @positional_deprecated
 def simple_evaluate(
@@ -260,12 +262,16 @@ def evaluate(
             metrics, example = output
             example.update(fewshot_logging_info)
             example.update(task.get_logging_info())
+            logger = logging.getLogger("examples")
+            logger.info(json.dumps(example))
             examples.append(example)
         else:
             metrics = output
             example = fewshot_logging_info
             example.update(task.get_logging_info())
             examples.append(example)
+            logger = logging.getLogger("examples")
+            logger.info(json.dumps(example))
 
         for metric, value in metrics.items():
             vals[(task_prompt_name, metric)].append(value)

--- a/main.py
+++ b/main.py
@@ -83,6 +83,7 @@ def setup_example_logger(output_path):
 
 
 def main():
+    os.makedirs("./outputs", exist_ok=True)
     args = parse_args()
     assert not args.provide_description  # not implemented
 
@@ -120,7 +121,6 @@ def main():
             parallelize=args.parallelize,
         )
 
-    os.makedirs("./outputs", exist_ok=True)
     with open(f"./outputs/agg-{output_path}.json", "w") as f:
         json.dump({"results": results["results"], "config": results["config"]}, f)
 

--- a/main.py
+++ b/main.py
@@ -72,6 +72,7 @@ def args_to_name(args):
 
 
 def setup_example_logger(output_path):
+    """Sets up a logger that will save each example and prediction."""
     logger = logging.getLogger("examples")
     filename = f"./outputs/examples-{output_path}.jsonl"
     formatter = logging.Formatter("%(message)s")

--- a/main.py
+++ b/main.py
@@ -71,6 +71,16 @@ def args_to_name(args):
     return filename
 
 
+def setup_example_logger(output_path):
+    logger = logging.getLogger("examples")
+    filename = f"./outputs/examples-{output_path}.jsonl"
+    formatter = logging.Formatter("%(message)s")
+    handler = logging.FileHandler(filename)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
 def main():
     args = parse_args()
     assert not args.provide_description  # not implemented
@@ -90,6 +100,9 @@ def main():
         with open(args.description_dict_path, "r") as f:
             description_dict = json.load(f)
 
+    output_path = args_to_name(args)
+    setup_example_logger(output_path)
+
     with OfflineEmissionsTracker(country_iso_code="FRA"):
         results = evaluator.simple_evaluate(
             model=args.model,
@@ -106,10 +119,7 @@ def main():
             parallelize=args.parallelize,
         )
 
-    output_path = args_to_name(args)
     os.makedirs("./outputs", exist_ok=True)
-    with open(f"./outputs/examples-{output_path}.json", "w") as f:
-        json.dump({"examples": results["examples"], "config": results["config"]}, f)
     with open(f"./outputs/agg-{output_path}.json", "w") as f:
         json.dump({"results": results["results"], "config": results["config"]}, f)
 


### PR DESCRIPTION
* Currently we store all examples during all of evaluation.
* In this PR, we log examples more frequently s.t. there is less ram usage
* In the very large datasets, holding all exampels (datasetsize x #prompts) might start to become problematic
* The example format will now be `.jsonl` -- its easy to read visually and can be processed with many libraries or something like `[json.loads(line) for line in file.readlines()]`