### PR TITLE
Add `loglikelihod_rolling` to `AutoSeq2SeqLM`

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -228,6 +228,34 @@ def test_make_disjoint_window():
     )
     assert make_disjoint_window(([1, 2, 3, 4, 5], [4, 5, 6])) == ([1, 2, 3], [4, 5, 6])
 
+def test_pad_windows():
+    token_list = [100, 19, 3, 9, 794, 7142, 81, 1327, 5]
+    # Representation: [([context], [continuation]), ...]
+    # [
+    #   ([1], [100, 19, 3, 9]), 
+    #   ([9], [794, 7142, 81, 1327]),
+    #   ([ ], [5])
+    # ]
+    rolling_token_windows = list(
+        map(
+            make_disjoint_window,
+            get_rolling_token_windows(
+                token_list=token_list,
+                prefix_token=1,
+                max_seq_len=4,
+                context_len=1,
+            ),
+        ))
+    expected = (
+        [[1], [9], [1]],  # Split & padded contexts.
+        [[100, 19, 3, 9], [794, 7142, 81, 1327], [5, 1, 1, 1]], # Split & padded continuations.
+    )
+    padded_windows = split_and_pad_windows(
+        rolling_token_windows,
+        pad_token=1,
+        max_seq_len=4,
+    )
+    assert padded_windows == expected
 
 def test_select_continuation_from_batch_1():
     generations = torch.tensor(


### PR DESCRIPTION
- Adds rolling loglikelihood to `AutoSeq2SeqLM` which is required by `PreplexityTask`s.
- Refactors `AutoSeq2SeqLM.loglikelihood` to match the structure of `AutoCausalLM.loglikelihood` 
   - Moves token-level loglikelihood logic into `_loglikelihood_tokens` 

Related Issue: #64