### PR TITLE
Put tokens on `device`

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -274,6 +274,8 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
         res = []
         for chunk in tqdm(requests, total=math.ceil(len(requests)), disable=disable_tqdm):
             cache_keys, inputs_tok, targets_tok = chunk
+            inputs_tok = inputs_tok.to(self.device)
+            targets_tok = targets_tok.to(self.device)
             outputs = self._model_call(inputs_tok, targets_tok)
             log_softmaxes = F.log_softmax(outputs.logits, dim=-1)
 


### PR DESCRIPTION
Tokens were never put on the user-specified device which resulted in the following error when `--device cuda`: 

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument index in method wrapper__index_select)
```