### PR TITLE
Initial draft of GAD.

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -11,6 +11,7 @@ from . import crows_pairs_multilingual
 from . import drop
 from . import e2e_nlg_cleaned
 from . import flores_101
+from . import gad
 from . import gem_asset_turk
 from . import gem_mlsum
 from . import gem_webnlg
@@ -158,6 +159,9 @@ TASK_REGISTRY = {
     # "storycloze_2016": storycloze.StoryCloze2016,
     # "storycloze_2018": storycloze.StoryCloze2018,
     # "sat": sat.SATAnalogies,
+
+    # GAD
+    "gad": gad.GadFold0Text,
     
     # GEM/xum
     "gem_xsum": gem_xsum.GEMXSUM,

--- a/lm_eval/tasks/gad.py
+++ b/lm_eval/tasks/gad.py
@@ -1,0 +1,53 @@
+"""
+Gad: A corpus identifying associations between genes and diseases by a semi-automatic annotation procedure based on the Genetic Association Database
+
+Homepage: "https://github.com/dmis-lab/biobert"
+"""
+from lm_eval.base import BioTask
+
+_CITATION = """
+@article{Bravo2015,
+  doi = {10.1186/s12859-015-0472-9},
+  url = {https://doi.org/10.1186/s12859-015-0472-9},
+  year = {2015},
+  month = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {16},
+  number = {1},
+  author = {{\`{A}}lex Bravo and Janet Pi{\~{n}}ero and N{\'{u}}ria Queralt-Rosinach and Michael Rautschka and Laura I Furlong},
+  title = {Extraction of relations between genes and diseases from text and large-scale data analysis: implications for translational research},
+  journal = {{BMC} Bioinformatics}
+}
+"""
+
+
+class GadBase(BioTask):
+    VERSION = 0
+    DATASET_PATH = "lm_eval/datasets/biomedical/bigbio/biodatasets/gad"
+    DATASET_NAME = None
+    SPLIT = None
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return True
+
+    def training_docs(self):
+        if self.has_training_docs():
+            return self.dataset["train"]
+
+    def validation_docs(self):
+        if self.has_validation_docs():
+            return self.dataset["validation"]
+
+    def test_docs(self):
+        if self.has_test_docs():
+            return self.dataset["test"]
+
+
+class GadFold0Text(GadBase):
+    DATASET_NAME = "gad_fold0_bigbio_text"


### PR DESCRIPTION
Current status:

When I execute the command
```
python main.py --model hf-seq2seq --model_args pretrained=t5-small --tasks gad --device cpu
```
I get the output
```
[codecarbon INFO @ 16:41:31] offline tracker init
/Users/bach/anaconda3/envs/bigbio/lib/python3.9/site-packages/transformers/models/t5/tokenization_t5_fast.py:156: FutureWarning: This tokenizer was incorrectly instantiated with a model max length of 512 which will be corrected in Transformers v5.
For now, this behavior is kept to avoid breaking backwards compatibility when padding/encoding with `truncation is True`.
- Be aware that you SHOULD NOT rely on t5-small automatically truncating your input to 512 when padding/encoding.
- If you want to encode/pad to sequences longer than 512 you can either instantiate this tokenizer with `model_max_length` or pass `max_length` when encoding/padding.
- To avoid this warning, please instantiate this tokenizer with `model_max_length` set to your preferred value.
  warnings.warn(
Reusing dataset gad (/Users/bach/.cache/huggingface/datasets/gad/gad_fold0_bigbio_text/1.0.0/433947290558fbff6fc8c75a276eb8491339cbf90ee81eb3cdff151715addc8a)
100%|██████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 260.08it/s]
Constructing 'gad+Yes/No Entailment Framing' contexts and requests
100%|██████████████████████████████████████████████████████████████████████████| 534/534 [00:01<00:00, 273.39it/s]
Running loglikelihood requests
100%|█████████████████████████████████████████████████████████████████████████| 1068/1068 [00:38<00:00, 27.97it/s]
|Task|         Prompt          |Version|Metric|Value|   |Stderr|
|----|-------------------------|------:|------|----:|---|-----:|
|gad |Yes/No Entailment Framing|      0|acc   |    0|±  |     0|
```

This seems wrong for several reasons:
- Not sure why the prompt `Yes/No Entailment Framing` is showing up. That seems to be the same as the Scitail example
- 0% accuracy seems unlikely since it's a binary classification task with answer_choices specified.

Any help that @StellaAthena @jason-fries can provide is appreciated!