### PR TITLE
Biosses + GAD + BioAsq tasks and fixes

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -717,7 +717,7 @@ class PromptSourceTask(Task):
             The results of the requests created in construct_requests.
         """
         answer_choices_list = self.prompt.get_answer_choices_list(doc)
-        target = self.doc_to_target(doc)
+        target = [self.doc_to_target(doc)]  # N.SEELAM The target is a str, not a list of strs
         if answer_choices_list:
             # If answer_choices_list, then this is a ranked choice prompt.
             # NOTE: In the future, target could be a list of strings.
@@ -1052,7 +1052,7 @@ class BioTask(PromptSourceTask):
     *and* add additional custom processing, override `process_results`, `higher_is_better`, and `aggregation`.
     """
 
-    CONFIGURED_RANKED_CHOICE_PS_METRICS = set(["Accuracy"])
+    CONFIGURED_RANKED_CHOICE_PS_METRICS = set(["Accuracy", "Other"])
     CONFIGURED_GENERATION_PS_METRICS = set(["BLEU", "ROUGE", "SARI"])
     SPLIT = None
 

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -27,7 +27,7 @@ from . import wino_bias
 from . import wmt
 from . import cnn_dailymail
 from . import diabla
-
+from . import gad
 
 ########################################
 # All tasks
@@ -199,6 +199,20 @@ TASK_REGISTRY = {
     
     # SciTail
     "scitail": scitail.SciTailTE,
+
+    # All GAD Datasets
+    "gad0": gad.GadFold0Text,
+    "gad1": gad.GadFold1Text,
+    "gad2": gad.GadFold2Text,
+    "gad3": gad.GadFold3Text,
+    "gad4": gad.GadFold4Text,
+    "gad5": gad.GadFold5Text,
+    "gad6": gad.GadFold6Text,
+    "gad7": gad.GadFold7Text,
+    "gad8": gad.GadFold8Text,
+    "gad9": gad.GadFold9Text,
+
+
 }
 
 

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -211,7 +211,7 @@ TASK_REGISTRY = {
     "gad7": gad.GadFold7Text,
     "gad8": gad.GadFold8Text,
     "gad9": gad.GadFold9Text,
-    "gadblurb": gad.GadBlurbText,
+    "gad": gad.GadBlurbText,
 
     # Biosses
 

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -211,6 +211,9 @@ TASK_REGISTRY = {
     "gad7": gad.GadFold7Text,
     "gad8": gad.GadFold8Text,
     "gad9": gad.GadFold9Text,
+    "gadblurb": gad.GadBlurbText,
+
+    # Biosses
 
 
 }

--- a/lm_eval/tasks/gad.py
+++ b/lm_eval/tasks/gad.py
@@ -1,0 +1,79 @@
+"""
+Gad: A corpus identifying associations between genes and diseases by a semi-automatic annotation procedure based on the Genetic Association Database
+Homepage: "https://github.com/dmis-lab/biobert"
+"""
+from lm_eval.base import BioTask
+
+_CITATION = """
+@article{Bravo2015,
+  doi = {10.1186/s12859-015-0472-9},
+  url = {https://doi.org/10.1186/s12859-015-0472-9},
+  year = {2015},
+  month = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {16},
+  number = {1},
+  author = {{\`{A}}lex Bravo and Janet Pi{\~{n}}ero and N{\'{u}}ria Queralt-Rosinach and Michael Rautschka and Laura I Furlong},
+  title = {Extraction of relations between genes and diseases from text and large-scale data analysis: implications for translational research},
+  journal = {{BMC} Bioinformatics}
+}
+"""
+
+
+class GadBase(BioTask):
+    VERSION = 0
+    DATASET_PATH = "/home/natasha/Projects/hfbiomed/blurb_datasets/gad"
+    DATASET_NAME = None
+    SPLIT = None
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return True
+
+    def training_docs(self):
+        if self.has_training_docs():
+            return self.dataset["train"]
+
+    def validation_docs(self):
+        if self.has_validation_docs():
+            return self.dataset["validation"]
+
+    def test_docs(self):
+        if self.has_test_docs():
+            return self.dataset["test"]
+
+
+class GadFold0Text(GadBase):
+    DATASET_NAME = "gad_fold0_bigbio_text"
+
+class GadFold1Text(GadBase):
+    DATASET_NAME = "gad_fold1_bigbio_text"
+
+class GadFold2Text(GadBase):
+    DATASET_NAME = "gad_fold2_bigbio_text"
+
+class GadFold3Text(GadBase):
+    DATASET_NAME = "gad_fold3_bigbio_text"
+
+class GadFold4Text(GadBase):
+    DATASET_NAME = "gad_fold4_bigbio_text"
+
+class GadFold5Text(GadBase):
+    DATASET_NAME = "gad_fold5_bigbio_text"
+
+class GadFold6Text(GadBase):
+    DATASET_NAME = "gad_fold6_bigbio_text"
+
+class GadFold7Text(GadBase):
+    DATASET_NAME = "gad_fold7_bigbio_text"
+
+class GadFold8Text(GadBase):
+    DATASET_NAME = "gad_fold8_bigbio_text"
+
+class GadFold9Text(GadBase):
+    DATASET_NAME = "gad_fold9_bigbio_text"

--- a/lm_eval/tasks/gad.py
+++ b/lm_eval/tasks/gad.py
@@ -22,7 +22,7 @@ _CITATION = """
 
 class GadBase(BioTask):
     VERSION = 0
-    DATASET_PATH = "/home/natasha/Projects/hfbiomed/blurb_datasets/gad"
+    DATASET_PATH = "/home/natasha/Projects/hfbiomed/full_prompting_pipeline/biomedical/bigbio/biodatasets/gad"
     DATASET_NAME = None
     SPLIT = None
 
@@ -47,6 +47,9 @@ class GadBase(BioTask):
         if self.has_test_docs():
             return self.dataset["test"]
 
+class GadBlurbText(GadBase):
+    """BLURB split from GAD, based on fold1"""
+    DATASET_NAME = "gad_blurb_bigbio_text"
 
 class GadFold0Text(GadBase):
     DATASET_NAME = "gad_fold0_bigbio_text"


### PR DESCRIPTION
WIP!

TLDR: I need to change some aspects of how `base` runs in order to work with binary classification. I am not sure why that is the case but inspection of the target seems to return an explicit str as opposed to a List of strs which fails the assertion [here](https://github.com/bigscience-workshop/lm-evaluation-harness/blob/ea1afe62423c4ff75d6579ccc6942ad8b5138298/lm_eval/base.py#L724)

Adds the BIOSSES task to Lm-Eval. Some notes:

- The path to BIOSSES needs to be changed for the user; this is hardcoded in. I can write a relative path if necessary
- I had to change `base.py`. Namely in the following lines:

* [Line 720](https://github.com/bigscience-workshop/lm-evaluation-harness/blob/ea1afe62423c4ff75d6579ccc6942ad8b5138298/lm_eval/base.py#L720) I was running into an assertion error. Inspection of the culprit suggested I was returning a str (Yes or No) not a List of str; Changing this into `target = [self.doc_to_target(doc)]` fixes the problem for me

* [Line 1055](https://github.com/bigscience-workshop/lm-evaluation-harness/blob/ea1afe62423c4ff75d6579ccc6942ad8b5138298/lm_eval/base.py#L1055) I added any other tasks that appear in the prompts here.

For GAD (see #80 I just borrowed this file for testing) my results were as follows:
```
|Task|                      Prompt                      |Version|Metric|Value |   |Stderr|
|----|--------------------------------------------------|------:|------|-----:|---|-----:|
|gad |Does this passage (passage first)                 |      0|acc   |0.4944|±  |0.0217|
|gad |Does this passage (passage last)                  |      0|acc   |0.4850|±  |0.0216|
|gad |I'm a doctor                                      |      0|acc   |0.5019|±  |0.0217|
|gad |Is there an association expressed? (passage first)|      0|acc   |0.5131|±  |0.0216|
|gad |Is there an association expressed? (passage last) |      0|acc   |0.4719|±  |0.0216|
```