### PR TITLE
[bugfix] Model name not extracted correctly when passing multiple args to `model_args`

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,12 +45,14 @@ def args_to_name(args):
     def _fix_model_name(model, model_args):
         if model_args == "":
             return model
-        elif "pretrained" in model_args:
-            # pretrained=google/t5-base-lm-adapt --> google-t5-base-lm-adapt
-            return model_args.split("=")[-1].replace("/", "-")
-        else:
+        elif "pretrained" not in model_args:
             print("WARNING: Unprepared for these model args.")
             return f"{model}_{model_args}"
+
+        #pretrained=google/t5-base-lm-adapt --> google-t5-base-lm-adapt
+        for arg in model_args.split(","):
+            if "pretrained" in arg:
+                return arg.split("=")[-1].replace("/", "-")
 
     fields = [
         _fix_model_name(args.model, args.model_args),


### PR DESCRIPTION
The model name is not extracted correctly when the `pretrained` argument is not the last one passed to `model_args`.

Current behavior:
```
python main.py \
        --model hf-causal \
        --model_args pretrained=gpt2,half=False \
        --tasks wnli --device cpu
```
generates files such as:
```
slim-False_wnli_0_1234_2022-06-16T17:37:36.261571.json
examples-False_wnli_0_1234_2022-06-16T17:37:36.261571.jsonl
```

This fix allows the `pretrained` arg to be correctly extracted, independent of the arg order passed to model_args.