### PR TITLE
Implement TyDi QA task

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -33,6 +33,7 @@ from . import diabla
 from . import xquad
 from . import schema_guided_dstc8
 from . import piaf
+from . import tydiqa
 
 
 ########################################
@@ -218,6 +219,9 @@ TASK_REGISTRY = {
     
     # SciTail
     "scitail": scitail.SciTailTE,
+    
+    # TyDi QA
+    "tydiqa_primary": tydiqa.TyDiQAPrimary,
 }
 
 

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -222,6 +222,7 @@ TASK_REGISTRY = {
     
     # TyDi QA
     "tydiqa_primary": tydiqa.TyDiQAPrimary,
+    "tydiqa_secondary": tydiqa.TyDiQASecondary
 }
 
 

--- a/lm_eval/tasks/tydiqa.py
+++ b/lm_eval/tasks/tydiqa.py
@@ -41,7 +41,7 @@ class TyDiQAPrimary(PromptSourceTask):
         return self.dataset["validation"]
 
     def invalid_doc_for_prompt(self, doc) -> bool:
-        # HACK: Some copa templates have conditionals that ignore documents
+        # HACK: Some templates have conditionals that ignore documents
         # when the condition is not met, like `{if doc['question'] != \"cause\"}`.
         # This means the prompt will never produce an input and target.
         # TODO: Remove this when fixed in `promptsource`
@@ -50,3 +50,69 @@ class TyDiQAPrimary(PromptSourceTask):
             return False
         except:
             return True
+        
+    class TyDiQASecondary(PromptSourceTask):
+    VERSION = 1
+    DATASET_PATH = "tydiqa"
+    DATASET_NAME = "secondary_task"
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return False
+
+    def training_docs(self):
+        if self._training_docs is None:
+            self._training_docs = list(self.dataset["train"])
+        return self._training_docs
+
+    def validation_docs(self):
+        return self.dataset["validation"]
+
+    def max_generation_length(self):
+        return 128
+
+    def compute_score(self, targets, pred, metric=compute_exact, agg=max):
+        return agg([metric(t, pred) for t in targets])
+
+    def process_results(self, doc, results):
+        # Based on PIAF's implementation
+        targets = self.doc_to_target(doc)
+        pred = results[0].strip()
+        agg_exact_match = self.compute_score(targets, pred, compute_exact)
+        agg_f1 = self.compute_score(targets, pred, compute_f1)
+        
+        out = {"f1": agg_f1, 
+                "exact_match": agg_exact_match}
+
+        if self.save_examples:
+            example = {"target": targets, "pred": pred}
+            return out, example
+        return out
+
+    def invalid_doc_for_prompt(self, doc) -> bool:
+        # HACK: Some templates have conditionals that ignore documents
+        # when the condition is not met, like `{if doc['question'] != \"cause\"}`.
+        # This means the prompt will never produce an input and target.
+        # TODO: Remove this when fixed in `promptsource`
+        try:
+            self.prompt.apply(doc)
+            return False
+        except:
+            return True
+    
+    def higher_is_better(self):
+        return {
+            "f1": True,
+            "exact_match": True,
+        }
+
+    def aggregation(self):
+        return {
+            "f1": mean,
+            "exact_match": mean,
+        }

--- a/lm_eval/tasks/tydiqa.py
+++ b/lm_eval/tasks/tydiqa.py
@@ -1,0 +1,52 @@
+"""
+TyDi QA: A Benchmark for Information-Seeking Question Answering in Typologically Diverse Languages
+
+TyDi QA is a question answering dataset covering 11 typologically diverse languages with 200K question-answer pairs.
+
+Paper: https://arxiv.org/abs/2003.05002
+Homepage: https://ai.google.com/research/tydiqa
+"""
+
+from lm_eval.base import PromptSourceTask
+
+_CITATION = """
+@article{tydiqa,
+    title   = {TyDi QA: A Benchmark for Information-Seeking Question Answering in Typologically Diverse Languages},
+    author  = {Jonathan H. Clark and Eunsol Choi and Michael Collins and Dan Garrette and Tom Kwiatkowski and Vitaly Nikolaev and Jennimaria Palomaki}
+    year    = {2020},
+    journal = {Transactions of the Association for Computational Linguistics}
+}
+"""
+
+class TyDiQAPrimary(PromptSourceTask):
+    VERSION = 1
+    DATASET_PATH = "tydiqa"
+    DATASET_NAME = "primary_task"
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return False
+
+    def training_docs(self):
+        if self._training_docs is None:
+            self._training_docs = list(self.dataset["train"])
+        return self._training_docs
+
+    def validation_docs(self):
+        return self.dataset["validation"]
+
+    def invalid_doc_for_prompt(self, doc) -> bool:
+        # HACK: Some copa templates have conditionals that ignore documents
+        # when the condition is not met, like `{if doc['question'] != \"cause\"}`.
+        # This means the prompt will never produce an input and target.
+        # TODO: Remove this when fixed in `promptsource`
+        try:
+            self.prompt.apply(doc)
+            return False
+        except:
+            return True

--- a/lm_eval/tasks/tydiqa.py
+++ b/lm_eval/tasks/tydiqa.py
@@ -51,7 +51,7 @@ class TyDiQAPrimary(PromptSourceTask):
         except:
             return True
         
-    class TyDiQASecondary(PromptSourceTask):
+class TyDiQASecondary(PromptSourceTask):
     VERSION = 1
     DATASET_PATH = "tydiqa"
     DATASET_NAME = "secondary_task"

--- a/lm_eval/tasks/tydiqa.py
+++ b/lm_eval/tasks/tydiqa.py
@@ -41,17 +41,7 @@ class TyDiQAPrimary(PromptSourceTask):
     def validation_docs(self):
         return self.dataset["validation"]
 
-    def invalid_doc_for_prompt(self, doc) -> bool:
-        # HACK: Some templates have conditionals that ignore documents
-        # when the condition is not met, like `{if doc['question'] != \"cause\"}`.
-        # This means the prompt will never produce an input and target.
-        # TODO: Remove this when fixed in `promptsource`
-        try:
-            self.prompt.apply(doc)
-            return False
-        except:
-            return True
-        
+
 class TyDiQASecondary(PromptSourceTask):
     VERSION = 1
     DATASET_PATH = "tydiqa"
@@ -94,17 +84,6 @@ class TyDiQASecondary(PromptSourceTask):
             example = {"target": targets, "pred": pred}
             return out, example
         return out
-
-    def invalid_doc_for_prompt(self, doc) -> bool:
-        # HACK: Some templates have conditionals that ignore documents
-        # when the condition is not met, like `{if doc['question'] != \"cause\"}`.
-        # This means the prompt will never produce an input and target.
-        # TODO: Remove this when fixed in `promptsource`
-        try:
-            self.prompt.apply(doc)
-            return False
-        except:
-            return True
     
     def higher_is_better(self):
         return {

--- a/lm_eval/tasks/tydiqa.py
+++ b/lm_eval/tasks/tydiqa.py
@@ -7,7 +7,8 @@ Paper: https://arxiv.org/abs/2003.05002
 Homepage: https://ai.google.com/research/tydiqa
 """
 
-from lm_eval.base import PromptSourceTask
+from lm_eval.base import PromptSourceTask, mean
+from transformers.data.metrics.squad_metrics import compute_exact, compute_f1
 
 _CITATION = """
 @article{tydiqa,


### PR DESCRIPTION
Supports both primary and secondary tasks.

## Primary

**mT5 0-shot**
```
|            prompt_name             |    metric    |     mean     |    stderr     |
|------------------------------------|--------------|-------------:|--------------:|
|   after_reading_the_text           |   acc        |   0.324680   |   0.0537120   |
|   after_reading_the_text           |   acc_norm   |   0.675320   |   0.0537120   |
|   based_on_the_text                |   acc        |   0.324680   |   0.0537120   |
|   based_on_the_text                |   acc_norm   |   0.675320   |   0.0537120   |
|   heres_what_I_found               |   acc        |   0.024248   |   0.0047928   |
|   heres_what_I_found               |   acc_norm   |   0.925320   |   0.0081911   |
|   open_domain_qa                   |   acc        |   0.324680   |   0.0537120   |
|   open_domain_qa                   |   acc_norm   |   0.675320   |   0.0537120   |
|   open_domain_qa_without_choices   |   acc        |   0.324680   |   0.0537120   |
|   open_domain_qa_without_choices   |   acc_norm   |   0.675320   |   0.0537120   |
|   read_and_answer                  |   acc        |   0.024248   |   0.0047928   |
|   read_and_answer                  |   acc_norm   |   0.925320   |   0.0081911   |
|   yes_no_none                      |   acc        |   0.024248   |   0.0047928   |
|   yes_no_none                      |   acc_norm   |   0.925320   |   0.0081911   |
|   yes_no_question                  |   acc        |   0.925320   |   0.0081911   |
|   yes_no_question                  |   acc_norm   |   0.074685   |   0.0081911   |
```


**mGPT 0-shot**
```
|            prompt_name             |    metric    |     mean     |    stderr     |
|------------------------------------|--------------|-------------:|--------------:|
|   after_reading_the_text           |   acc        |   0.324680   |   0.0537120   |
|   after_reading_the_text           |   acc_norm   |   0.649350   |   0.0547360   |
|   based_on_the_text                |   acc        |   0.324680   |   0.0537120   |
|   based_on_the_text                |   acc_norm   |   0.610390   |   0.0559390   |
|   heres_what_I_found               |   acc        |   0.064016   |   0.0076271   |
|   heres_what_I_found               |   acc_norm   |   0.808920   |   0.0122500   |
|   open_domain_qa                   |   acc        |   0.675320   |   0.0537120   |
|   open_domain_qa                   |   acc_norm   |   0.675320   |   0.0537120   |
|   open_domain_qa_without_choices   |   acc        |   0.649350   |   0.0547360   |
|   open_domain_qa_without_choices   |   acc_norm   |   0.675320   |   0.0537120   |
|   read_and_answer                  |   acc        |   0.061106   |   0.0074633   |
|   read_and_answer                  |   acc_norm   |   0.809890   |   0.0122260   |
|   yes_no_none                      |   acc        |   0.192050   |   0.0122740   |
|   yes_no_none                      |   acc_norm   |   0.888460   |   0.0098089   |
|   yes_no_question                  |   acc        |   0.077595   |   0.0083360   |
|   yes_no_question                  |   acc_norm   |   0.074685   |   0.0081911   |
```

## Secondary

**mT5 0-shot**
```
|                  prompt_name                  |     metric      |     mean      |     stderr     |
|-----------------------------------------------|-----------------|--------------:|---------------:|
|   can_you_answer_the_question                 |   f1            |   0.0413010   |   0.00350020   |
|   can_you_answer_the_question                 |   exact_match   |   0.0000000   |   0.00000000   |
|   can_you_tell_me_the_answer                  |   f1            |   0.0375120   |   0.00311770   |
|   can_you_tell_me_the_answer                  |   exact_match   |   0.0000000   |   0.00000000   |
|   end_to_end_question_generation              |   f1            |   0.0460520   |   0.00186890   |
|   end_to_end_question_generation              |   exact_match   |   0.0000000   |   0.00000000   |
|   end_to_end_question_generation_with_title   |   f1            |   0.0527280   |   0.00167120   |
|   end_to_end_question_generation_with_title   |   exact_match   |   0.0000000   |   0.00000000   |
|   extract_answer                              |   f1            |   0.0335330   |   0.00310530   |
|   extract_answer                              |   exact_match   |   0.0000000   |   0.00000000   |
|   simple_question_odqa                        |   f1            |   0.0038395   |   0.00062105   |
|   simple_question_odqa                        |   exact_match   |   0.0000000   |   0.00000000   |
|   testing_students                            |   f1            |   0.0385890   |   0.00292000   |
|   testing_students                            |   exact_match   |   0.0000000   |   0.00000000   |
|   title_generation                            |   f1            |   0.0342690   |   0.00155690   |
|   title_generation                            |   exact_match   |   0.0000000   |   0.00000000   |
|   whats_the_answer                            |   f1            |   0.0394050   |   0.00326510   |
|   whats_the_answer                            |   exact_match   |   0.0000000   |   0.00000000   |
```

**mGPT 0-shot**
```
|                  prompt_name                  |     metric      |     mean     |    stderr     |
|-----------------------------------------------|-----------------|-------------:|--------------:|
|   can_you_answer_the_question                 |   f1            |   0.022628   |   0.0023525   |
|   can_you_answer_the_question                 |   exact_match   |   0.000000   |   0.0000000   |
|   can_you_tell_me_the_answer                  |   f1            |   0.029359   |   0.0026356   |
|   can_you_tell_me_the_answer                  |   exact_match   |   0.000000   |   0.0000000   |
|   end_to_end_question_generation              |   f1            |   0.049463   |   0.0017658   |
|   end_to_end_question_generation              |   exact_match   |   0.000000   |   0.0000000   |
|   end_to_end_question_generation_with_title   |   f1            |   0.050734   |   0.0017829   |
|   end_to_end_question_generation_with_title   |   exact_match   |   0.000000   |   0.0000000   |
|   extract_answer                              |   f1            |   0.025137   |   0.0022843   |
|   extract_answer                              |   exact_match   |   0.000000   |   0.0000000   |
|   simple_question_odqa                        |   f1            |   0.011317   |   0.0010795   |
|   simple_question_odqa                        |   exact_match   |   0.000000   |   0.0000000   |
|   testing_students                            |   f1            |   0.034168   |   0.0028024   |
|   testing_students                            |   exact_match   |   0.000000   |   0.0000000   |
|   title_generation                            |   f1            |   0.023644   |   0.0015280   |
|   title_generation                            |   exact_match   |   0.000000   |   0.0000000   |
|   whats_the_answer                            |   f1            |   0.020688   |   0.0021814   |
|   whats_the_answer                            |   exact_match   |   0.000000   |   0.0000000   |
```

**GPT-J 8-shot** (so we know the task is working properly)
```
|                  prompt_name                  |     metric      |     mean      |    stderr     |
|-----------------------------------------------|-----------------|--------------:|--------------:|
|   can_you_answer_the_question                 |   f1            |   0.5933700   |   0.0203460   |
|   can_you_answer_the_question                 |   exact_match   |   0.4386400   |   0.0236830   |
|   can_you_tell_me_the_answer                  |   f1            |   0.0484380   |   0.0067761   |
|   can_you_tell_me_the_answer                  |   exact_match   |   0.0090909   |   0.0045299   |
|   end_to_end_question_generation              |   f1            |   0.2599000   |   0.0117630   |
|   end_to_end_question_generation              |   exact_match   |   0.0113640   |   0.0050588   |
|   end_to_end_question_generation_with_title   |   f1            |   0.2472000   |   0.0117160   |
|   end_to_end_question_generation_with_title   |   exact_match   |   0.0136360   |   0.0055352   |
|   extract_answer                              |   f1            |   0.0604430   |   0.0078152   |
|   extract_answer                              |   exact_match   |   0.0159090   |   0.0059718   |
|   simple_question_odqa                        |   f1            |   0.2111300   |   0.0166300   |
|   simple_question_odqa                        |   exact_match   |   0.1159100   |   0.0152780   |
|   testing_students                            |   f1            |   0.5194600   |   0.0211430   |
|   testing_students                            |   exact_match   |   0.3840900   |   0.0232140   |
|   title_generation                            |   f1            |   0.4192300   |   0.0192800   |
|   title_generation                            |   exact_match   |   0.2545500   |   0.0207900   |
|   whats_the_answer                            |   f1            |   0.5205600   |   0.0209940   |
|   whats_the_answer                            |   exact_match   |   0.3795500   |   0.0231610   |```