### PR TITLE
Extract example formatting from `fewshot_context`

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -297,10 +297,9 @@ class PromptSourceTask(Task):
         return False
 
     def format_example(self, text: str, target: str, separator: str) -> str:
-        """Decouple how the text and target are combined from the context generation.
-        """
+        """Decouple how the text and target are combined from the context generation."""
         return text + separator + target
-    
+
     def fewshot_examples(
         self,
         docs: datasets.Dataset,
@@ -390,7 +389,9 @@ class PromptSourceTask(Task):
                 # Choose 1 random target from multi-reference targets.
                 target_idx = int(rng.integers(0, len(targets)))
                 target = targets[target_idx].strip()
-                labeled_examples_list.append(self.format_example(text, target, text_target_separator))
+                labeled_examples_list.append(
+                    self.format_example(text, target, text_target_separator)
+                )
                 fewshot_target_idx.append(target_idx)
 
             labeled_examples = (

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -296,6 +296,11 @@ class PromptSourceTask(Task):
         """
         return False
 
+    def format_example(self, text: str, target: str, separator: str) -> str:
+        """Decouple how the text and target are combined from the context generation.
+        """
+        return text + separator + target
+    
     def fewshot_examples(
         self,
         docs: datasets.Dataset,
@@ -336,6 +341,7 @@ class PromptSourceTask(Task):
         num_fewshot: int,
         description: Optional[str] = None,
         example_separator: Optional[str] = "\n###\n",
+        text_target_separator: Optional[str] = " ",
         rng: Optional[np.random.Generator] = None,
     ) -> Tuple[str, dict]:
         """Returns a fewshot context string that is made up of a prepended description
@@ -384,7 +390,7 @@ class PromptSourceTask(Task):
                 # Choose 1 random target from multi-reference targets.
                 target_idx = int(rng.integers(0, len(targets)))
                 target = targets[target_idx].strip()
-                labeled_examples_list.append(f"{text} {target}")
+                labeled_examples_list.append(self.format_example(text, target, text_target_separator))
                 fewshot_target_idx.append(target_idx)
 
             labeled_examples = (
@@ -393,7 +399,7 @@ class PromptSourceTask(Task):
 
         description = description + "\n\n" if description else ""
         prompt = self.doc_to_text(doc)
-        ctx = description + labeled_examples + prompt
+        ctx = description + labeled_examples + prompt + text_target_separator
         logging_info = {
             "fewshot_idx": fewshot_idx,
             "fewshot_target_idx": fewshot_target_idx,


### PR DESCRIPTION
The way each example is constructed is currently hardcoded in `fewshot_context`. This PR refactors it out and allows the separator to be customised.