### PR TITLE
Change the required torch version to >=1.9 from >= 1.7 for accelerate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "sacrebleu==1.5.0",
     "scikit-learn>=0.24.1",
     "sqlitedict==1.6.0",
-    "torch>=1.7",
+    "torch>=1.9",
     "tqdm-multiprocess==0.0.11",
     "accelerate@git+https://github.com/huggingface/accelerate@main",
     "transformers@git+https://github.com/huggingface/transformers@main",


### PR DESCRIPTION
The torch version required to use the 'big model inference' is >=1.9.  "In Transformers 4.20.0, the [from_pretrained()](https://huggingface.co/docs/transformers/v4.20.1/en/main_classes/model#transformers.PreTrainedModel.from_pretrained) method has been reworked to accommodate large models using [Accelerate](https://huggingface.co/docs/accelerate/big_modeling). This requires Accelerate >= 0.9.0 and PyTorch >= 1.9.0"

https://huggingface.co/docs/transformers/v4.20.1/en/main_classes/model#large-model-loading
https://huggingface.co/docs/transformers/v4.20.1/en/main_classes/model#transformers.PreTrainedModel.from_pretrained

How to reproduce an error on Colab:
https://colab.research.google.com/drive/1iBZkiV22E98GLH5PXFVExFm6-_mJVLyP?usp=sharing

I suspect this did not come up as an error since the Colab and the machines we have been running the script on have the correct torch version installed already.