### PR TITLE
Re-add `wmt` to registry and include more years

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -116,9 +116,21 @@ TASK_REGISTRY = {
     "xquad_ar": xquad.XQuADArabic,
     # PIAF
     "piaf": piaf.PIAF,
-    # TyDi QA
-    "tydiqa_primary": tydiqa.TyDiQAPrimaryClassification,
-    "tydiqa_secondary": tydiqa.TyDiQAGoldPGeneration,
+    # GEM/WebNLG
+    # Format: `GEM/web_nlg_{webnlg.subset_name}_{split}`
+    **gem_webnlg.construct_tasks(),
+    # GEM/WikiAssetTurk
+    # Format: `GEM/wiki_auto_asset_turk_{split}`
+    **gem_asset_turk.construct_tasks(),
+    # GEM WikiLingua
+    # Format: `GEM/wiki_lingua_{lang}`
+    **gem_wikilingua.construct_tasks(),
+    # Flores101
+    # Format: `gsarti/flores_101_{lang}`
+    **flores_101.construct_tasks(),
+    # WMT
+    # Format: `wmt{year}_{lang1}_{lang2}`
+    **wmt.construct_tasks(),
     # BLiMP
     "blimp_adjunct_island": blimp.BlimpAdjunctIsland,
     "blimp_anaphor_gender_agreement": blimp.BlimpAnaphorGenderAgreement,
@@ -187,21 +199,9 @@ TASK_REGISTRY = {
     "blimp_wh_vs_that_no_gap_long_distance": blimp.BlimpWhVsThatNoGapLongDistance,
     "blimp_wh_vs_that_with_gap": blimp.BlimpWhVsThatWithGap,
     "blimp_wh_vs_that_with_gap_long_distance": blimp.BlimpWhVsThatWithGapLongDistance,
-    # GEM/WebNLG
-    # Format: `GEM/web_nlg_{webnlg.subset_name}_{split}`
-    **gem_webnlg.construct_tasks(),
-    # GEM/WikiAssetTurk
-    # Format: `GEM/wiki_auto_asset_turk_{split}`
-    **gem_asset_turk.construct_tasks(),
-    # GEM WikiLingua
-    # Format: `GEM/wiki_lingua_{lang}`
-    **gem_wikilingua.construct_tasks(),
-    # Flores101
-    # Format: `gsarti/flores_101_{lang}`
-    **flores_101.construct_tasks(),
-    # WMT
-    # Format: `wmt{year}_{lang1}_{lang2}`
-    **wmt.construct_tasks(),
+    # TyDi QA
+    "tydiqa_primary": tydiqa.TyDiQAPrimaryClassification,
+    "tydiqa_secondary": tydiqa.TyDiQAGoldPGeneration,
     #######################################################
     # TODO: Not Yet Available in `promptsource/eval-hackathon`
     ########################################################

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -116,18 +116,9 @@ TASK_REGISTRY = {
     "xquad_ar": xquad.XQuADArabic,
     # PIAF
     "piaf": piaf.PIAF,
-    # GEM/WebNLG
-    # Format: `GEM/web_nlg_{webnlg.subset_name}_{split}`
-    **gem_webnlg.construct_tasks(),
-    # GEM/WikiAssetTurk
-    # Format: `GEM/wiki_auto_asset_turk_{split}`
-    **gem_asset_turk.construct_tasks(),
-    # GEM WikiLingua
-    # Format: `GEM/wiki_lingua_{lang}`
-    **gem_wikilingua.construct_tasks(),
-    # Flores101
-    # Format: `gsarti/flores_101_{lang}`
-    **flores_101.construct_tasks(),
+    # TyDi QA
+    "tydiqa_primary": tydiqa.TyDiQAPrimaryClassification,
+    "tydiqa_secondary": tydiqa.TyDiQAGoldPGeneration,
     # BLiMP
     "blimp_adjunct_island": blimp.BlimpAdjunctIsland,
     "blimp_anaphor_gender_agreement": blimp.BlimpAnaphorGenderAgreement,
@@ -196,15 +187,24 @@ TASK_REGISTRY = {
     "blimp_wh_vs_that_no_gap_long_distance": blimp.BlimpWhVsThatNoGapLongDistance,
     "blimp_wh_vs_that_with_gap": blimp.BlimpWhVsThatWithGap,
     "blimp_wh_vs_that_with_gap_long_distance": blimp.BlimpWhVsThatWithGapLongDistance,
-    # TyDi QA
-    "tydiqa_primary": tydiqa.TyDiQAPrimaryClassification,
-    "tydiqa_secondary": tydiqa.TyDiQAGoldPGeneration,
+    # GEM/WebNLG
+    # Format: `GEM/web_nlg_{webnlg.subset_name}_{split}`
+    **gem_webnlg.construct_tasks(),
+    # GEM/WikiAssetTurk
+    # Format: `GEM/wiki_auto_asset_turk_{split}`
+    **gem_asset_turk.construct_tasks(),
+    # GEM WikiLingua
+    # Format: `GEM/wiki_lingua_{lang}`
+    **gem_wikilingua.construct_tasks(),
+    # Flores101
+    # Format: `gsarti/flores_101_{lang}`
+    **flores_101.construct_tasks(),
+    # WMT
+    # Format: `wmt{year}_{lang1}-{lang2}`
+    **wmt.construct_tasks(),
     #######################################################
     # TODO: Not Yet Available in `promptsource/eval-hackathon`
     ########################################################
-    # WMT
-    # Format: `wmt{year}_{lang1}-{lang2}`
-    # **wmt.create_year_tasks(wmt.WMT14_TASKS),
     # GEM/mlsum
     # "mlsum_es": gem_mlsum.GEMMLSUMEs,
     # "mlsum_de": gem_mlsum.GEMMLSUMDe,

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -200,7 +200,7 @@ TASK_REGISTRY = {
     # Format: `gsarti/flores_101_{lang}`
     **flores_101.construct_tasks(),
     # WMT
-    # Format: `wmt{year}_{lang1}-{lang2}`
+    # Format: `wmt{year}_{lang1}_{lang2}`
     **wmt.construct_tasks(),
     #######################################################
     # TODO: Not Yet Available in `promptsource/eval-hackathon`


### PR DESCRIPTION
- Re-adds `wmt` to the task registry now that it is available in `promptsource/eval-hackathon`.
- Adds all `wmt` years with prompt templates from `promptsource`.