### PR TITLE
Add unpacking to trigger invalid `promptsource` docs

### DIFF
--- a/lm_eval/tasks/e2e_nlg_cleaned.py
+++ b/lm_eval/tasks/e2e_nlg_cleaned.py
@@ -65,7 +65,7 @@ class E2E_NLG_Cleaned(PromptSourceTask):
         # This means the prompt will never produce an input and target.
         # TODO: Remove this when fixed in `promptsource`
         try:
-            self.prompt_template.apply(doc)
+            text, target = self.prompt_template.apply(doc)
             return (
                 self.prompt_template.name.endswith("_qa")
                 or self.prompt_template.name == "family_friendly_yes_no"

--- a/lm_eval/tasks/superglue.py
+++ b/lm_eval/tasks/superglue.py
@@ -142,7 +142,7 @@ class Copa(PromptSourceTask):
         # This means the prompt will never produce an input and target.
         # TODO: Remove this when fixed in `promptsource`
         try:
-            self.prompt_template.apply(doc)
+            text, target = self.prompt_template.apply(doc)
             return False
         except Exception:
             return True

--- a/lm_eval/tasks/tydiqa.py
+++ b/lm_eval/tasks/tydiqa.py
@@ -53,7 +53,7 @@ class TyDiQAPrimaryClassification(PromptSourceTask):
         # This means the prompt will never produce an input and target.
         # TODO: Remove this when fixed in `promptsource`
         try:
-            text, _ = self.prompt_template.apply(doc)
+            text, target = self.prompt_template.apply(doc)
             return False
         except Exception:
             return True
@@ -156,7 +156,7 @@ class TyDiQAGoldPGeneration(PromptSourceTask):
         # TODO: Remove this when fixed in `promptsource`
         try:
             # Ensure the `apply` returns 2 values.
-            text, _ = self.prompt_template.apply(doc)
+            text, target = self.prompt_template.apply(doc)
             return False
         except Exception:
             return True


### PR DESCRIPTION
- Add unpacking to force filtering invalid prompts when `promptsource` doesn't properly return a target on `apply`.
- Related Issue: #65