### PR TITLE
Update `revision` to handle subfolder specification

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -176,8 +176,7 @@ class HuggingFaceAutoLM(TokenLM):
         """Returns a pre-trained tokenizer from a pre-trained tokenizer configuration."""
         tokenizer = transformers.AutoTokenizer.from_pretrained(
             pretrained if tokenizer is None else tokenizer,
-            revision=revision,
-            subfolder=subfolder,
+            revision=revision + ("/" + subfolder if subfolder is not None else ""),
         )
         tokenizer.pad_token = tokenizer.eos_token
         return tokenizer


### PR DESCRIPTION
- Passing `None` to the optional `subfolder` argument of `AutoTokenizer.from_pretrained` is broken. This hacks in a subfolder specification into the `revision` arg as done in the `AutoModel<>.from_pretrained` initializer.