### PR TITLE
Revert option for minimum generation length

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -4,7 +4,6 @@ import json
 import os
 import torch
 import torch.nn.functional as F
-from sqlitedict import SqliteDict
 from tqdm import tqdm
 from typing import Iterable, List, Optional, Tuple, Union
 from transformers import BatchEncoding
@@ -374,6 +373,7 @@ class CachingLM:
         :param cache_db: str
             Path to cache db
         """
+        from sqlitedict import SqliteDict
         self.lm = lm
         if os.path.dirname(cache_db):
             os.makedirs(os.path.dirname(cache_db), exist_ok=True)

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -374,6 +374,7 @@ class CachingLM:
             Path to cache db
         """
         from sqlitedict import SqliteDict
+
         self.lm = lm
         if os.path.dirname(cache_db):
             os.makedirs(os.path.dirname(cache_db), exist_ok=True)

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -341,7 +341,6 @@ class AutoCausalLM(HuggingFaceAutoLM):
             stopping_criteria=stopping_criteria,
             do_sample=False,
         )
-        print("GENERATIONS", generations.shape, generations)
         return utils.select_continuation_from_batch_left_padding(
             generations, max_context_size=inputs["input_ids"].size(1)
         )
@@ -505,9 +504,6 @@ class MultiTokenEOSCriteria(transformers.StoppingCriteria):
         last_token_id = input_ids[0, -self.sequence_id_len :]
         last_tokens = self.tokenizer.decode(last_token_id)
         is_stopped = self.sequence in last_tokens
-        print("STOPPED", is_stopped)
-        print("LASTTOKS", last_tokens)
-        print("SEQ", self.sequence)
         return is_stopped
 
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -65,7 +65,7 @@ class HuggingFaceAutoLM(TokenLM):
         subfolder: Optional[str] = None,
         revision: Optional[str] = "main",
         batch_size: Optional[int] = 1,
-        min_gen_toks: Optional[int] = 1,
+        min_gen_toks: Optional[int] = 0,
         max_gen_toks: Optional[int] = 256,
         max_length: Optional[int] = None,
         use_accelerate: Optional[bool] = False,
@@ -482,8 +482,10 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
         self, inputs: TokenSequence, max_tokens: int, min_tokens: int, stop: Optional[List[str]] = None
     ) -> Union[TokenSequence, List[str]]:
         stopping_criteria = stop_sequences_criteria(self.tokenizer, stop)
+        min_length = inputs["input_ids"].shape[1] + min_tokens
         generations = self.model.generate(
             **inputs,
+            min_length=min_length,
             max_length=max_tokens,
             stopping_criteria=stopping_criteria,
             do_sample=False,

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -204,8 +204,8 @@ TASK_REGISTRY = {
     # TODO: Not Yet Available in `promptsource/eval-hackathon`
     ########################################################
     # GEM/mlsum
-    # "mlsum_es": gem_mlsum.GEMMLSUMEs,
-    # "mlsum_de": gem_mlsum.GEMMLSUMDe,
+    "mlsum_es": gem_mlsum.GEMMLSUMEs,
+    "mlsum_de": gem_mlsum.GEMMLSUMDe,
     # "mlsum_es_covid_challenge_set": gem_mlsum.GEMMLSUMEsChallgeTestCovid,
     # "mlsum_de_covid_challenge_set": gem_mlsum.GEMMLSUMDeChallgeTestCovid,
     # LAMA

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -204,8 +204,8 @@ TASK_REGISTRY = {
     # TODO: Not Yet Available in `promptsource/eval-hackathon`
     ########################################################
     # GEM/mlsum
-    "mlsum_es": gem_mlsum.GEMMLSUMEs,
-    "mlsum_de": gem_mlsum.GEMMLSUMDe,
+    # "mlsum_es": gem_mlsum.GEMMLSUMEs,
+    # "mlsum_de": gem_mlsum.GEMMLSUMDe,
     # "mlsum_es_covid_challenge_set": gem_mlsum.GEMMLSUMEsChallgeTestCovid,
     # "mlsum_de_covid_challenge_set": gem_mlsum.GEMMLSUMDeChallgeTestCovid,
     # LAMA

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import datetime
 import json
 import logging
 import os
-from codecarbon import OfflineEmissionsTracker
 
 import lm_eval.evaluator as evaluator
 from lm_eval.api import utils
@@ -178,6 +177,7 @@ def main():
             bootstrap_iters=args.bootstrap_iters,
         )
     else:
+        from codecarbon import OfflineEmissionsTracker
         with OfflineEmissionsTracker(country_iso_code="FRA", log_level="error"):
             print()  # Add newline between emissions tracker and evaluation logging.
             results = evaluator.cli_evaluate(

--- a/main.py
+++ b/main.py
@@ -178,6 +178,7 @@ def main():
         )
     else:
         from codecarbon import OfflineEmissionsTracker
+
         with OfflineEmissionsTracker(country_iso_code="FRA", log_level="error"):
             print()  # Add newline between emissions tracker and evaluation logging.
             results = evaluator.cli_evaluate(


### PR DESCRIPTION
the previous implementation was slightly incorrect due to padding on input_ids I think
Would have to e.g. sum across the attention mask to determine the shortest sequence. Instead it's cleaner to just set it to None imo.

You may not want to merge the mlsum changes though 
