### PR TITLE
Hard-code `seed`s to reduce non-deterministic behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,54 +56,43 @@ python main.py \
 ### Detailed Usage
 
 ```
-usage: main.py [-h] --model_api_name MODEL_API_NAME [--model_args MODEL_ARGS]
-               --task_name TASK_NAME [--template_names TEMPLATE_NAMES]
-               [--num_fewshot NUM_FEWSHOT] [--batch_size BATCH_SIZE]
-               [--device DEVICE] [--limit LIMIT] [--output_path OUTPUT_PATH]
-               [--template_idx TEMPLATE_IDX] [--bootstrap_iters BOOTSTRAP_ITERS]
-               [--no_tracking] [--seed SEED] [--use_cache]
+usage: main.py [-h] --model_api_name MODEL_API_NAME [--model_args MODEL_ARGS] --task_name TASK_NAME
+               [--template_names TEMPLATE_NAMES] [--num_fewshot NUM_FEWSHOT] [--batch_size BATCH_SIZE]
+               [--device DEVICE] [--limit LIMIT] [--output_path OUTPUT_PATH] [--template_idx TEMPLATE_IDX]
+               [--bootstrap_iters BOOTSTRAP_ITERS] [--no_tracking] [--use_cache]
 
 optional arguments:
   -h, --help            show this help message and exit
   --model_api_name MODEL_API_NAME
-                        Name of the model API to use. See
-                        `lm_eval.list_model_apis()` for available APIs
+                        Name of the model API to use. See `lm_eval.list_model_apis()` for available APIs
   --model_args MODEL_ARGS
-                        Model constructor args that you'd pass into a model of
-                        type `--model_api_name`. These must be comma-separated
-                        keyword args, e.g. `key1=value1,key2=value2`, with no
-                        spaces
+                        Model constructor args that you'd pass into a model of type `--model_api_name`. These must
+                        be comma-separated keyword args, e.g. `key1=value1,key2=value2`, with no spaces
   --task_name TASK_NAME
-                        Name of the task to use as found in the lm_eval registry.
-                        See: `lm_eval.list_tasks()`
+                        Name of the task to use as found in the lm_eval registry. See: `lm_eval.list_tasks()`
   --template_names TEMPLATE_NAMES
-                        Comma-separated list of template names for the specified
-                        task. Example: `> python main.py ... --task_name rte
-                        --template_names imply,mean`
+                        Comma-separated list of template names for the specified task. Example:
+                        `> python main.py ... --task_name rte --template_names imply,mean`
                         - Default: `all_templates`
                         - General Selectors:
                             - `"all_templates"`: Selects all templates for the task
-                            - `"original_templates"`: Selects only templates that are
-                                designed to match the original task
+                            - `"original_templates"`: Selects only templates that are designed to match the original task
   --num_fewshot NUM_FEWSHOT
   --batch_size BATCH_SIZE
-  --device DEVICE       The device to place your model onto, e.g. cuda:0. For
-                        large models available through the HuggingFace Hub you
-                        should use `accelerate` by passing `use_accelerate=True`
-                        to `--model_args`
-  --limit LIMIT         Limit the number of examples to evaluate on; ONLY USE
-                        THIS FOR DEBUGGING PURPOSES
+  --device DEVICE       The device to place your model onto, e.g. cuda:0. For large models available through the
+                        HuggingFace Hub you should use `accelerate` by passing `use_accelerate=True` to
+                        `--model_args`
+  --limit LIMIT         Limit the number of examples to evaluate on; ONLY USE THIS FOR DEBUGGING PURPOSES
   --output_path OUTPUT_PATH
-                        Use output_path as `output_filename`. For example: `>
-                        python main.py ... --output_path blop` # saves files into
-                        `outputs/blop.json` Warning: You currently cannot
-                        change/add folder structure.
+                        Use output_path as `output_filename`. For example:
+                        `> python main.py ... --output_path blop`
+                        # saves files into `outputs/blop.json` Warning: You currently cannot change/add folder
+                        structure.
   --template_idx TEMPLATE_IDX
                         Choose template by index from available templates
   --bootstrap_iters BOOTSTRAP_ITERS
                         Iters for stderr computation
   --no_tracking         Skip carbon emission tracking
-  --seed SEED           The seed to be put through all RNGs
   --use_cache           Whether to cache your model's predictions or not
 ```
 

--- a/lm_eval/api/utils.py
+++ b/lm_eval/api/utils.py
@@ -1,6 +1,5 @@
 import collections
 import pathlib
-import random
 import re
 import sys
 import numpy
@@ -17,13 +16,20 @@ class ExitCodeError(Exception):
     pass
 
 
-def set_seed(seed: int) -> None:
-    """Set all the random seeds."""
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-    random.seed(seed)
-    transformers_set_seed(seed)
-    numpy.random.seed(seed)
+# Reproducibility utils
+
+
+def get_seed() -> int:
+    """Returns a hard-coded global seed for reproducibility."""
+    return 1234
+
+
+def set_seed() -> None:
+    transformers_set_seed(get_seed())
+
+
+def get_rng() -> numpy.random.Generator:
+    return numpy.random.default_rng(get_seed())
 
 
 # Token Utils

--- a/main.py
+++ b/main.py
@@ -88,9 +88,6 @@ def parse_args():
         "--no_tracking", action="store_true", help="Skip carbon emission tracking"
     )
     parser.add_argument(
-        "--seed", type=int, default=1234, help="The seed to be put through all RNGs"
-    )
-    parser.add_argument(
         "--use_cache",
         action="store_true",
         help="Whether to cache your model's predictions or not",
@@ -121,7 +118,7 @@ def args_to_name(args):
         args.task_name,
         args.template_names,
         str(args.num_fewshot),
-        str(args.seed),
+        str(utils.get_seed()),
         datetime.datetime.now().isoformat(),
     ]
     fields = [f for f in fields if f is not None]
@@ -173,7 +170,6 @@ def main():
             device=args.device,
             use_cache=args.use_cache,
             limit=args.limit,
-            seed=args.seed,
             bootstrap_iters=args.bootstrap_iters,
         )
     else:
@@ -191,7 +187,6 @@ def main():
                 device=args.device,
                 use_cache=args.use_cache,
                 limit=args.limit,
-                seed=args.seed,
                 bootstrap_iters=args.bootstrap_iters,
             )
 

--- a/scripts/agg2slim.py
+++ b/scripts/agg2slim.py
@@ -1,6 +1,10 @@
 import glob
 import json
 import os
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def agg2slim(data):
@@ -22,7 +26,7 @@ def agg2slim(data):
     results = data["results"]
     config = data["config"]
     if isinstance(config, list):
-        print("Warning! This is an old agg file with a buggy config.")
+        logger.warning("Warning! This is an old agg file with a buggy config.")
         # If information needs to be recovered, we can recover it from the filename.
         config = {}
     slim = {
@@ -45,7 +49,7 @@ def main():
             data = json.load(jf)
         slim_json_filename = agg_json_filename.replace("agg", "slim")
         if os.path.exists(slim_json_filename):
-            print("Skipping file as it already exists.")
+            logger.info("Skipping file as it already exists.")
         slim = agg2slim(data)
         with open(slim_json_filename, "w") as jf:
             json.dump(slim, jf, indent=2)

--- a/scripts/make_gpt2_test_cases.py
+++ b/scripts/make_gpt2_test_cases.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn.functional as F
 import random
 
-random.seed(42)
+from lm_eval.api.utils import set_seed
 
 
 data = [
@@ -24,10 +24,8 @@ tok = transformers.GPT2Tokenizer.from_pretrained("gpt2")
 
 tgs = []
 
+set_seed()
 for dat in data:
-    random.seed(dat)
-    # print(model(tok.encode(dat, return_tensors="pt"))[0][0])
-
     tokens = tok.encode(dat, return_tensors="pt")
     ind = random.randrange(len(tokens[0]) - 1)
     logits = F.log_softmax(model(tokens)[0], dim=-1)[:, :-1]  # [batch, seq, vocab]

--- a/scripts/write_out.py
+++ b/scripts/write_out.py
@@ -1,5 +1,4 @@
 import argparse
-import numpy as np
 import os
 
 import lm_eval
@@ -16,14 +15,13 @@ def parse_args():
     parser.add_argument("--template_names", default="all_templates")
     parser.add_argument("--sets", type=str, default="val")  # example: val,test
     parser.add_argument("--num_fewshot", type=int, default=1)
-    parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--num_examples", type=int, default=1)
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
-    rng = np.random.default_rng(args.seed)
+    rng = utils.get_rng()
 
     template_names = utils.cli_template_names(args.task_name, args.template_names)
     tasks = lm_eval.get_task_list(args.task_name, template_names)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,5 +1,4 @@
 import os
-import numpy as np
 import random
 import pytest
 
@@ -8,10 +7,7 @@ import lm_eval.tasks as tasks
 import lm_eval.api.model as model
 import lm_eval.models as models
 import lm_eval.evaluator as evaluator
-from lm_eval.api.utils import set_seed
-
-
-_SEED = 42
+from lm_eval.api.utils import set_seed, get_seed
 
 
 # TODO: More fine grained unit tests rather than this big honking integration
@@ -27,7 +23,7 @@ def _ll_fn(requests):
         assert ctx[-1] != " "
         assert cont[0] == " "
     res = []
-    random.seed(_SEED)
+    random.seed(get_seed())
     for _ in requests:
         res.append((-random.random(), False))
     return res
@@ -37,7 +33,7 @@ def _ll_perp_fn(requests):
     for (string,) in requests:
         assert isinstance(string, str)
     res = []
-    random.seed(_SEED)
+    random.seed(get_seed())
     for _ in requests:
         res.append(-random.random())
     return res
@@ -45,7 +41,7 @@ def _ll_perp_fn(requests):
 
 @pytest.mark.parametrize("task_name", lm_eval.list_tasks())
 def test_evaluator(task_name):
-    set_seed(_SEED)
+    set_seed()
     template_names = tasks.list_templates(task_name)
     # Only choose 1 promptsource template.
     template_name = template_names[0] if template_names else None
@@ -63,7 +59,6 @@ def test_evaluator(task_name):
         num_fewshot=0,
         bootstrap_iters=10,
         limit=limit,
-        rng=np.random.default_rng(_SEED),
     )["results"]
     e2 = evaluator.evaluate(
         model=lm,
@@ -71,7 +66,6 @@ def test_evaluator(task_name):
         num_fewshot=0,
         bootstrap_iters=10,
         limit=limit,
-        rng=np.random.default_rng(_SEED),
     )["results"]
     # Check that caching is working
     assert e1 == e2

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,10 +2,11 @@ import pytest
 import random
 
 import lm_eval.api.metric as metrics
+from lm_eval.api.utils import get_seed
 
 
 def test_bootstrapping():
-    random.seed(42)
+    random.seed(get_seed())
     arr = [random.random() for _ in range(1000)]
     expected = metrics.mean_stderr(arr)
     bootstrapped = metrics.bootstrap_stderr(metrics.mean, arr, iters=100000)

--- a/tests/test_models_huggingface.py
+++ b/tests/test_models_huggingface.py
@@ -1,14 +1,17 @@
 import unittest.mock as mock
+import logging
 import pytest
 
 import lm_eval.models
 from lm_eval.api.utils import set_seed
 
 
+logger = logging.getLogger(__name__)
+
+
 # Only use cpu to avoid non-deterministic CUDA settings.
 # See: https://pytorch.org/docs/stable/notes/randomness.html
 _DEVICE = "cpu"
-_SEED = 42
 
 
 @pytest.mark.parametrize(
@@ -25,7 +28,7 @@ _SEED = 42
     ],
 )
 def test_stop_sequences(stop_sequences, test_input, expected):
-    set_seed(_SEED)
+    set_seed()
     causal_model = lm_eval.models.get_model(
         "hf-causal", pretrained="gpt2", device=_DEVICE
     )
@@ -46,7 +49,7 @@ def test_stop_sequences(stop_sequences, test_input, expected):
 
 
 def test_causal_model():
-    set_seed(_SEED)
+    set_seed()
     causal_model = lm_eval.models.get_model(
         "hf-causal",
         pretrained="gpt2",
@@ -140,6 +143,7 @@ def test_causal_model():
 
 
 def test_causal_model_perplexity():
+    set_seed()
     causal_model = lm_eval.models.get_model_from_args_string(
         model_api_name="hf-causal", model_args=f"device={_DEVICE},pretrained=gpt2"
     )
@@ -178,7 +182,7 @@ def test_causal_model_perplexity():
             model_api_name="hf-causal", model_args=f"device={_DEVICE},pretrained=gpt2"
         )
         perplexity = causal_model.loglikelihood_rolling([(test_string,)])[0]
-        print(perplexity)
+        logger.info(perplexity)
     tgt = sum(
         [
             -4.96001,

--- a/tests/test_models_openai_completions.py
+++ b/tests/test_models_openai_completions.py
@@ -5,8 +5,13 @@ import openai
 import mock
 import pickle
 import hashlib
+import logging
 
 import lm_eval.models as models
+from lm_eval.api.utils import set_seed
+
+
+logger = logging.getLogger(__name__)
 
 
 def _mock_completion(**kwargs):
@@ -30,6 +35,7 @@ def _mock_completion(**kwargs):
 
 @mock.patch("lm_eval.models.openai_completions.oa_completion", new=_mock_completion)
 def test_openai_completions():
+    set_seed()
     if "OPENAI_API_SECRET_KEY" not in os.environ:
         os.environ["OPENAI_API_SECRET_KEY"] = ""
     oa_model = models.get_model_from_args_string(
@@ -107,7 +113,7 @@ def test_openai_completions():
     )
     assert gen == " dog"
 
-    print([x[0] for x in vals])
+    logger.info([x[0] for x in vals])
 
     targets = [
         -34.848301606999996,
@@ -126,6 +132,7 @@ def test_openai_completions():
 
 @mock.patch("lm_eval.models.openai_completions.oa_completion", new=_mock_completion)
 def test_openai_completions_perplexity():
+    set_seed()
     if "OPENAI_API_SECRET_KEY" not in os.environ:
         os.environ["OPENAI_API_SECRET_KEY"] = ""
     oa_model = models.get_model_from_args_string(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from typing import Optional, Tuple
 from itertools import islice
@@ -6,9 +7,10 @@ from promptsource.templates import Template
 import lm_eval.tasks as tasks
 from lm_eval.api.task import Task
 from lm_eval.api.request import Request
+from lm_eval.api.utils import set_seed
 
 
-_SEED = 42
+logger = logging.getLogger(__name__)
 
 
 def _get_deterministic_template(
@@ -46,7 +48,7 @@ def _filter_docs(task: Task):
 
 @pytest.mark.parametrize("task_name,task_class", tasks.TASK_REGISTRY.items())
 def test_basic_interface(task_name: str, task_class: Task):
-    print("Evaluating task", task_name)
+    logger.info("Evaluating task", task_name)
     prompt_template, is_deterministic = _get_deterministic_template(task_name)
     task = task_class(prompt_template=prompt_template)
 
@@ -100,7 +102,8 @@ def test_basic_interface(task_name: str, task_class: Task):
 
 @pytest.mark.parametrize("task_name,task_class", tasks.TASK_REGISTRY.items())
 def test_documents_and_requests(task_name: str, task_class: Task):
-    print("Evaluating task", task_name)
+    set_seed()
+    logger.info("Evaluating task", task_name)
     prompt_template, _ = _get_deterministic_template(task_name)
     task = task_class(prompt_template=prompt_template)
 

--- a/tests/test_version_stable.py
+++ b/tests/test_version_stable.py
@@ -6,6 +6,7 @@ import hashlib
 import collections
 
 import lm_eval
+from lm_eval.api.utils import get_seed, set_seed
 
 
 def _assert_target(name, ob):
@@ -60,6 +61,7 @@ def _flatten(d, parent_key="", sep="."):
 @pytest.mark.skip(reason="Version stability are not setup for `PropmtSourceTask`s")
 # @pytest.mark.parametrize("task_name,task_class", tasks.TASK_REGISTRY.items())
 def test_versions_stable(task_name, task_class):
+    set_seed()
     os.makedirs("tests/testdata", exist_ok=True)
     task = lm_eval.get_task(task_name)
     model = lm_eval.get_model("dummy")
@@ -77,7 +79,7 @@ def test_versions_stable(task_name, task_class):
         )
         res = []
 
-        random.seed(42)
+        random.seed(get_seed())
         for _ in requests:
             res.append((-random.random(), False))
 
@@ -92,7 +94,7 @@ def test_versions_stable(task_name, task_class):
         )
         res = []
 
-        random.seed(42)
+        random.seed(get_seed())
         for _ in requests:
             res.append(-random.random())
 


### PR DESCRIPTION
- Hard-codes the seed as in the [main EleutherAI harness](https://github.com/EleutherAI/lm-evaluation-harness/blob/b0b76d87fc84b2bfdfa88b71ce4592f35f707428/lm_eval/evaluator.py#L56) to remove an added source of non-deterministic behavior. Note this removes the optional seed arg in the CLI.
- Moves seed setter and random number generator getter into the `evaluate` function to ensure library users properly handle the `numpy`, `random`, etc. seeding.

cc @samsontmr for input since we've run into repro issues with seeding together.