### PR TITLE
Lazy import `pytest` in utils module

### DIFF
--- a/lm_eval/api/utils.py
+++ b/lm_eval/api/utils.py
@@ -3,7 +3,6 @@ import pathlib
 import re
 import sys
 import numpy
-import pytest
 import torch
 from typing import Callable, Iterable, List, Tuple, Union
 from transformers import set_seed as transformers_set_seed
@@ -321,6 +320,8 @@ def find_test_root(*, start_path: pathlib.Path) -> pathlib.Path:
 
 def run_task_tests(*, task_list: List[str]):
     """Find the package root and run the tests for the given tasks."""
+    import pytest
+
     package_root = find_test_root(start_path=pathlib.Path(__file__))
     task_string = " or ".join(task_list)
     args = [


### PR DESCRIPTION
- Lazily import `pytest` to avoid run time errors when pip installing at the user-level (i.e.  when installing via `pip install -e .` instead of `pip install -e ".[dev]"`)