### PR TITLE
Fix stopping criteria to avoid early termination of generation

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -536,6 +536,7 @@ class MultiTokenEOSCriteria(transformers.StoppingCriteria):
         self.sequence = sequence
         self.sequence_ids = tokenizer.encode(sequence, add_special_tokens=False)
         self.sequence_id_len = len(self.sequence_ids)
+        self.tokenizer = tokenizer
 
     def __call__(self, input_ids, scores, **kwargs) -> bool:
         # For efficiency, we compare the last n tokens where n is the number of tokens in the stop_sequence
@@ -543,10 +544,12 @@ class MultiTokenEOSCriteria(transformers.StoppingCriteria):
             :, -self.sequence_id_len :
         ]
         
+        lookback_tokens_batch = self.tokenizer.batch_decode(lookback_ids_batch)        
+        
         for i, done in enumerate(self.done_tracker):
             if not done:
                 self.done_tracker[i] = (
-                    self.sequence_ids == lookback_ids_batch[i].tolist()
+                    self.sequence in lookback_tokens_batch[i]
                 )        
         return False not in self.done_tracker
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -336,7 +336,7 @@ class AutoCausalLM(HuggingFaceAutoLM):
     ) -> TokenSequence:
         input_ids = inputs["input_ids"][:, self.max_gen_toks - self.max_length :]
         input_ids = input_ids.to(self.device)
-        
+
         attention_mask = inputs["attention_mask"][
             :, self.max_gen_toks - self.max_length :
         ]
@@ -344,7 +344,7 @@ class AutoCausalLM(HuggingFaceAutoLM):
         stopping_criteria = stop_sequences_criteria(
             self.tokenizer, stop, input_ids.shape[1], input_ids.shape[0]
         )
-        
+
         generations = self.model.generate(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -499,7 +499,7 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
         # Generate one token to calculate the number of start tokens prepended to decoder_input_ids
         one_tok_gen = self.model.generate(
             input_ids=torch.zeros((1, 1), dtype=torch.int),
-            min_length=2, 
+            min_length=2,
             max_new_tokens=1,
         ).squeeze()
 
@@ -525,10 +525,10 @@ class MultiTokenEOSCriteria(transformers.StoppingCriteria):
     """
 
     def __init__(
-        self, 
-        sequence: str, 
-        tokenizer: transformers.PreTrainedTokenizer, 
-        initial_decoder_input_length: int, 
+        self,
+        sequence: str,
+        tokenizer: transformers.PreTrainedTokenizer,
+        initial_decoder_input_length: int,
         batch_size: int,
     ):
         self.initial_decoder_input_length = initial_decoder_input_length
@@ -543,14 +543,12 @@ class MultiTokenEOSCriteria(transformers.StoppingCriteria):
         lookback_ids_batch = input_ids[:, self.initial_decoder_input_length :][
             :, -self.sequence_id_len :
         ]
-        
+
         lookback_tokens_batch = self.tokenizer.batch_decode(lookback_ids_batch)        
-        
+
         for i, done in enumerate(self.done_tracker):
             if not done:
-                self.done_tracker[i] = (
-                    self.sequence in lookback_tokens_batch[i]
-                )        
+                self.done_tracker[i] = self.sequence in lookback_tokens_batch[i]
         return False not in self.done_tracker
 
 
@@ -565,7 +563,8 @@ def stop_sequences_criteria(
             *[
                 MultiTokenEOSCriteria(
                     sequence, tokenizer, initial_decoder_input_length, batch_size
-                ) for sequence in stop_sequences
+                )
+                for sequence in stop_sequences
             ],
         ]
     )

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -560,7 +560,7 @@ def stop_sequences_criteria(
             *[
                 MultiTokenEOSCriteria(
                     sequence, tokenizer, initial_decoder_input_length, batch_size
-                )
+                ) for sequence in stop_sequences
             ],
         ]
     )

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -544,7 +544,7 @@ class MultiTokenEOSCriteria(transformers.StoppingCriteria):
             :, -self.sequence_id_len :
         ]
 
-        lookback_tokens_batch = self.tokenizer.batch_decode(lookback_ids_batch)        
+        lookback_tokens_batch = self.tokenizer.batch_decode(lookback_ids_batch)
 
         for i, done in enumerate(self.done_tracker):
             if not done:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -341,7 +341,9 @@ class AutoCausalLM(HuggingFaceAutoLM):
             :, self.max_gen_toks - self.max_length :
         ]
         attention_mask = attention_mask.to(self.device)
-        
+        stopping_criteria = stop_sequences_criteria(
+            self.tokenizer, stop, input_ids.shape[1], input_ids.shape[0]
+        )
         
         generations = self.model.generate(
             input_ids=input_ids,

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -496,17 +496,18 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
         input_ids = inputs["input_ids"][:, -self.max_length :].to(self.device)
         attention_mask = inputs["attention_mask"][:, -self.max_length :].to(self.device)
 
-        # Generate one token to calculate the number of start tokens prepended to decoder_input_ids
-        one_tok_gen = self.model.generate(
-            input_ids=torch.zeros((1, 1), dtype=torch.int),
-            min_length=2,
-            max_new_tokens=1,
-        ).squeeze()
+        # Generate one token to calculate the number of start tokens prepended to decoder_input_ids 
+        # (leaving this here in case the below assumption is violated in the future)
+        #one_tok_gen = self.model.generate(
+        #    input_ids=torch.zeros((1, 1), dtype=torch.int),
+        #    min_length=2,
+        #    max_new_tokens=1,
+        #).squeeze()
+        #initial_decoder_input_length = len(one_tok_gen) - 1
 
-        initial_decoder_input_length = len(one_tok_gen) - 1
-
+        # Assume that there will always only be one token in the decoder inputs, assumption holds for existing HF models
         stopping_criteria = stop_sequences_criteria(
-            self.tokenizer, stop, initial_decoder_input_length, input_ids.shape[0]
+            self.tokenizer, stop, 1, input_ids.shape[0]
         )
 
         generations = self.model.generate(

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -493,8 +493,8 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
         max_tokens: int,
         stop: Optional[List[str]] = None,
     ) -> Union[TokenSequence, List[str]]:
-        input_ids = inputs["input_ids"].to(self.device)
-        attention_mask = inputs["attention_mask"].to(self.device)
+        input_ids = inputs["input_ids"][:, -self.max_length :].to(self.device)
+        attention_mask = inputs["attention_mask"][:, -self.max_length :].to(self.device)
 
         # Generate one token to calculate the number of start tokens prepended to decoder_input_ids
         # (leaving this here in case the below assumption is violated in the future)

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -288,6 +288,7 @@ class HuggingFaceAutoLM(TokenLM):
             responses = self.tok_decode(responses.tolist())
 
             for response in responses:
+                # Ensure the generated responses do not contain the stop sequences.
                 for term in until:
                     response = response.split(term)[0]
                 # partial caching

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -328,7 +328,7 @@ class AutoCausalLM(HuggingFaceAutoLM):
 
     def _model_generate(
         self,
-        inputs: TokenSequence,
+        inputs: transformers.BatchEncoding,
         max_tokens: int,
         stop: Optional[List[str]] = None,
     ) -> TokenSequence:
@@ -489,10 +489,10 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
 
     def _model_generate(
         self,
-        inputs: TokenSequence,
+        inputs: transformers.BatchEncoding,
         max_tokens: int,
         stop: Optional[List[str]] = None,
-    ) -> Union[TokenSequence, List[str]]:
+    ) -> TokenSequence:
         input_ids = inputs["input_ids"][:, -self.max_length :].to(self.device)
         attention_mask = inputs["attention_mask"][:, -self.max_length :].to(self.device)
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -338,7 +338,7 @@ class AutoCausalLM(HuggingFaceAutoLM):
         attention_mask = inputs["attention_mask"][:, self.max_gen_toks - self.max_length :].to(self.device)
         stopping_criteria = stop_sequences_criteria(
             self.tokenizer, stop, input_ids.shape[1], input_ids.shape[0]
-            )
+        )
         generations = self.model.generate(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -492,7 +492,7 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
 
         # Generate one token to calculate the number of start tokens prepended to decoder_input_ids
         one_tok_gen = self.model.generate(
-            input_ids=torch.zeros((1,1), dtype=torch.int), min_length=2, max_new_tokens=1
+            input_ids=torch.zeros((1, 1), dtype=torch.int), min_length=2, max_new_tokens=1
         ).squeeze()
 
         initial_decoder_input_length = len(one_tok_gen) - 1


### PR DESCRIPTION
the current implementation of `MultiTokenEOSCriteria` causes `model.generate()` to terminate whenever a stop token is generated for the first example in the batch. This is due to `last_token_id` (the generated token) being always retrieved from the first example: 
```
last_token_id = input_ids[0, -self.sequence_id_len :]
```

This PR modifies `MultiTokenEOSCriteria` to compare and track the generated tokens of each example in the batch and only return `True` when the model has generated a stop token for all examples .