### PR TITLE
Add a `add_special_tokens` property to the `HuggingFaceAutoLM` base class

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -83,6 +83,8 @@ class HuggingFaceAutoLM(TokenLM):
             Whether to add special tokens to the input sequences. If `None`, the
             default value will be set to `True` for seq2seq models (e.g. T5) and
             `False` for causal models.
+            WARNING: Evaluating causal models with `add_special_tokens=True` is
+            currently __not__ supported.
         :param use_accelerate:
             If True, uses the `accelerate` library to load a large model across
             multiple devices.
@@ -116,6 +118,15 @@ class HuggingFaceAutoLM(TokenLM):
         assert isinstance(pretrained, str)
         assert isinstance(device, str)
         assert isinstance(batch_size, int)
+        if add_special_tokens is not None:
+            # TODO: Support evaluating causal models with special tokens. Currently,
+            # this is not possible because the `_loglikelihood_tokens()` method for
+            # causal LMs makes a no-special-tokens assumption given that contexts
+            # and labels/continuations are tokenized separately without special
+            # tokens, concatenated, and then processed as inputs.
+            assert (
+                self.AUTO_MODEL_CLASS is not transformers.AutoModelForCausalLM
+            ), "Evaluating causal models with `add_special_tokens=True` is currently not supported."
 
         self._batch_size = batch_size  # TODO: Adaptive batch size
         self._max_gen_toks = max_gen_toks

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -230,10 +230,7 @@ class HuggingFaceAutoLM(TokenLM):
         """Whether to include special tokens in encoded text. This should be
         determined by whether or not the model was trained with special tokens.
 
-        TODO (jon-tow): Make this customizable for users after the BigScience
-        paper is released.
-
-        NOTE: This is a hard-coded hack until HuggingFace supports a way to
+        TODO: This is a hard-coded hack. Update once HuggingFace supports a way to
         check whether or not an arbitrary model was trained with special tokens.
         """
         raise NotImplementedError()

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -278,24 +278,17 @@ class HuggingFaceAutoLM(TokenLM):
             else:
                 max_tokens = max_generation_length
 
-            # Ensure that the context does not encroach into the `space`
-            # for the generation.
             token_context = self.tok_encode_batch(context)
-            input_ids = token_context["input_ids"][
-                :, self.max_gen_toks - self.max_length :
-            ].to(self.device)
-            attention_mask = token_context["attention_mask"][
-                :, self.max_gen_toks - self.max_length :
-            ].to(self.device)
 
             responses = self._model_generate(
-                inputs={"input_ids": input_ids, "attention_mask": attention_mask},
+                inputs=token_context,
                 max_tokens=max_tokens,
                 stop=until,
             )
             responses = self.tok_decode(responses.tolist())
 
             for response in responses:
+                # Ensure the generated responses do not contain the stop sequences.
                 for term in until:
                     response = response.split(term)[0]
                 # partial caching
@@ -336,13 +329,26 @@ class AutoCausalLM(HuggingFaceAutoLM):
 
     def _model_generate(
         self,
-        inputs: TokenSequence,
+        inputs: transformers.BatchEncoding,
         max_tokens: int,
         stop: Optional[List[str]] = None,
     ) -> TokenSequence:
-        stopping_criteria = stop_sequences_criteria(self.tokenizer, stop)
+        # Ensure that the context does not encroach into the `space`
+        # for the generation.
+        input_ids = inputs["input_ids"][:, self.max_gen_toks - self.max_length :]
+        attention_mask = inputs["attention_mask"][
+            :, self.max_gen_toks - self.max_length :
+        ]
+        input_ids = input_ids.to(self.device)
+        attention_mask = attention_mask.to(self.device)
+
+        stopping_criteria = stop_sequences_criteria(
+            self.tokenizer, stop, input_ids.shape[1], input_ids.shape[0]
+        )
+
         generations = self.model.generate(
-            **inputs,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
             # GPT style models require the `generate` `max_length` arg to include the
             # context length, so we instead set `max_new_tokens` which is the number
             # of new tokens to generate, excluding the current number of tokens.
@@ -484,13 +490,30 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
 
     def _model_generate(
         self,
-        inputs: TokenSequence,
+        inputs: transformers.BatchEncoding,
         max_tokens: int,
         stop: Optional[List[str]] = None,
-    ) -> Union[TokenSequence, List[str]]:
-        stopping_criteria = stop_sequences_criteria(self.tokenizer, stop)
+    ) -> TokenSequence:
+        input_ids = inputs["input_ids"][:, -self.max_length :].to(self.device)
+        attention_mask = inputs["attention_mask"][:, -self.max_length :].to(self.device)
+
+        # Generate one token to calculate the number of start tokens prepended to decoder_input_ids
+        # (leaving this here in case the below assumption is violated in the future)
+        # one_tok_gen = self.model.generate(
+        #    input_ids=torch.zeros((1, 1), dtype=torch.int),
+        #    min_length=2,
+        #    max_new_tokens=1,
+        # ).squeeze()
+        # initial_decoder_input_length = len(one_tok_gen) - 1
+
+        # Assume that there will always only be one token in the decoder inputs, assumption holds for existing HF models
+        stopping_criteria = stop_sequences_criteria(
+            self.tokenizer, stop, 1, input_ids.shape[0]
+        )
+
         generations = self.model.generate(
-            **inputs,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
             max_new_tokens=max_tokens,
             stopping_criteria=stopping_criteria,
             do_sample=False,
@@ -499,30 +522,50 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
 
 
 class MultiTokenEOSCriteria(transformers.StoppingCriteria):
-    """Criteria to stop on the specified multi-token sequence."""
+    """
+    Criteria to stop on the specified multi-token sequence.
+    """
 
-    def __init__(self, sequence: str, tokenizer: transformers.PreTrainedTokenizer):
+    def __init__(
+        self,
+        sequence: str,
+        tokenizer: transformers.PreTrainedTokenizer,
+        initial_decoder_input_length: int,
+        batch_size: int,
+    ):
+        self.initial_decoder_input_length = initial_decoder_input_length
+        self.done_tracker = [False] * batch_size
         self.sequence = sequence
-        self.sequence_id = tokenizer.encode(sequence)
-        self.sequence_id_len = len(self.sequence_id) + 1
+        self.sequence_ids = tokenizer.encode(sequence, add_special_tokens=False)
+        self.sequence_id_len = len(self.sequence_ids)
         self.tokenizer = tokenizer
 
-    def __call__(
-        self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs
-    ) -> bool:
-        last_token_id = input_ids[0, -self.sequence_id_len :]
-        last_tokens = self.tokenizer.decode(last_token_id)
-        is_stopped = self.sequence in last_tokens
-        return is_stopped
+    def __call__(self, input_ids, scores, **kwargs) -> bool:
+        # For efficiency, we compare the last n tokens where n is the number of tokens in the stop_sequence
+        lookback_ids_batch = input_ids[:, self.initial_decoder_input_length :][
+            :, -self.sequence_id_len :
+        ]
+
+        lookback_tokens_batch = self.tokenizer.batch_decode(lookback_ids_batch)
+
+        for i, done in enumerate(self.done_tracker):
+            if not done:
+                self.done_tracker[i] = self.sequence in lookback_tokens_batch[i]
+        return False not in self.done_tracker
 
 
 def stop_sequences_criteria(
-    tokenizer: transformers.PreTrainedTokenizer, stop_sequences: List[str]
+    tokenizer: transformers.PreTrainedTokenizer,
+    stop_sequences: List[str],
+    initial_decoder_input_length: int,
+    batch_size: int,
 ) -> transformers.StoppingCriteriaList:
     return transformers.StoppingCriteriaList(
         [
             *[
-                MultiTokenEOSCriteria(sequence, tokenizer)
+                MultiTokenEOSCriteria(
+                    sequence, tokenizer, initial_decoder_input_length, batch_size
+                )
                 for sequence in stop_sequences
             ],
         ]

--- a/tests/test_models_huggingface.py
+++ b/tests/test_models_huggingface.py
@@ -45,9 +45,22 @@ def test_causal_stop_sequences(stop_sequences, test_input, expected):
 @pytest.mark.parametrize(
     "stop_sequences,test_input,expected",
     [
-        (["symbiosis"], "bigscience is ", "bigscience is a symbiosis"),
-        (["of"], "which is ", "which is a symphony of"),
-        (["</s>"], "which is ", "which is a symphony of a symphony of a "),
+        (["better"], "big science is ", "big science is a great way to get a better"),
+        (
+            ["the"],
+            "big science is ",
+            "big science is a great way to get a better understanding of the",
+        ),
+        (
+            ["."],
+            "The quick brown fox jumps over the lazy ",
+            "The quick brown fox jumps over the lazy fox.",
+        ),
+        (
+            ["</s>"],
+            "big science is ",
+            "big science is a great way to get a better understanding of the world.",
+        ),
     ],
 )
 def test_seq2seq_stop_sequences(stop_sequences, test_input, expected):
@@ -221,3 +234,93 @@ def test_causal_model_perplexity():
         ]
     )
     assert perplexity == pytest.approx(tgt, rel=1e-3)
+
+
+def test_seq2seq_model():
+    seq2seq_model = lm_eval.models.get_model(
+        "hf-seq2seq",
+        pretrained="google/t5-small-lm-adapt",
+        device=_DEVICE,
+    )
+    llhs = seq2seq_model.loglikelihood(
+        [
+            ("The quick brown fox jumps over the lazy", " dog"),
+            ("The quick brown fox jumps over the lazy", " cat"),
+            ("The quick brown fox jumps over the lazy", ", lazy dog"),
+            ("The quick brown fox jumps over the lazy", "<pad> fox."),
+            (
+                "The quick brown fox jumps over the lazy",
+                ", lazy fox and they both fall to the ground",
+            ),
+            (
+                """A mult""",
+                """ilayer perceptron (MLP) is a class of feedforward artificial neural network (ANN)""",
+            ),
+            (
+                """The term MLP is used ambiguously, sometimes loosely to any feedforward ANN, sometimes strictly to refer to networks composed of multiple layers of perceptrons""",
+                """ (with threshold activation); see § Terminology""",
+            ),
+            (
+                """Multilayer perceptrons are sometimes coll""",
+                """oquially referred to as "vanilla" neural networks, especially when they have a single hidden layer.[1]""",
+            ),
+            (
+                """An MLP consists of at least three layers of nodes: an input layer, a hidden layer and an output layer. Except for the input nodes, each node is a neuron that uses a nonlinear""",
+                """ activation function.""",
+            ),
+            (
+                """MLP utilizes a supervised""",
+                """ learning technique called backpropagation for training.[2][3] Its multiple layers and non-linear activation distinguish MLP from a linear perceptron. It can distinguish data that is not linearly separable.[4]""",
+            ),
+            (
+                """Recent work has demonstrated substantial gains on many NLP tasks and benchmarks by pre-training on a large corpus of text followed by fine-tuning on a specific task. While typically task-agnostic""",
+                """ in architecture, this method still requires task-specific fine-tuning datasets of thousands or tens of thousands of examples. By contrast, humans can generally perform a new language task from only a few examples or from simple instructions - something which current NLP systems still largely struggle to do. Here we show that scaling up language models greatly improves task-agnostic, few-shot performance, sometimes even reaching competitiveness with prior state-of-the-art fine-tuning approaches. """,
+            ),
+            (
+                """Specifically, we train GPT-3, an autoregressive language model with 175""",
+                """ billion parameters, 10x more than any previous non-sparse language model, and test its performance in the few-shot setting. For all tasks, GPT-3 is applied without any gradient updates or fine-tuning, with tasks and few-shot demonstrations specified purely via text interaction with the model. GPT-3 achieves strong performance on many NLP datasets, including translation, question-answering, and cloze tasks, as well as several tasks that require on-the-fly reasoning or domain adaptation, such as unscrambling words, using a novel word in a sentence, or performing 3-digit arithmetic. At the same time, we also identify some datasets where GPT-3's few-shot learning still struggles, as well as some datasets where GPT-3 faces methodological issues related to training on large web corpora. Finally, we find that GPT-3 can generate samples of news articles which human evaluators have difficulty distinguishing from articles written by humans. We discuss broader societal impacts of this finding and of GPT-3 in general.""",
+            ),
+            (
+                """A mult""",
+                """ilayer perceptron (MLP) is a class of feedforward artificial neural network (ANN)""",
+            ),
+            ("""Hello""", """ World"""),
+        ]
+    )
+    (
+        (ll_dog, ig_dog),
+        (ll_cat, ig_cat),
+        (_, ll_max_0),
+        (_, ll_max_1),
+        (_, ll_max_2),
+        *vals,
+    ) = llhs
+    assert ll_dog > ll_cat
+    assert not ig_cat
+
+    targets = [
+        -118.2639,
+        -70.3217,
+        -116.2367,
+        -16.5411,
+        -227.1213,
+        -393.8974,
+        -851.3747,
+        -118.2639,
+        -19.8556,
+    ]
+    for (pred, _), tgt in zip(vals, targets):
+        assert pred == pytest.approx(tgt, rel=1e-3)
+
+    # Test empty context
+    seq2seq_model.loglikelihood([("", "test")])
+
+    request_args = {
+        "stop_sequences": [".", "\n"],
+        "max_generation_length": 20,
+        "num_fewshot": 1,
+    }
+    (gen,) = seq2seq_model.greedy_until(
+        [("The quick brown fox jumps over the lazy", request_args)]
+    )
+    assert gen == "fox"


### PR DESCRIPTION
- Adds a `add_special_tokens` property to the `HuggingFaceAutoLM` base class to allow users to specify whether or not model inputs should be encoded with special tokens. 
  - Previously, special tokens were omitted from the tokenization of inputs/labels for Seq2Seq models, which most likely resulted in sub-optimal/unfair evaluations.
  - The defaults are now:
    - `add_special_tokens=False` for **causal** models and
    - `add_special_tokens=True` for **seq2seq** models
- Updates seq2seq model unit tests to reflect this change.