### PR TITLE
Remove `text_target_separtor` whitespace from Seq2SeqLM labels

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -247,9 +247,16 @@ class PromptSourceTask(Task):
             text_target_separator (str, optional, defaults to ' '):
                 The string that will be used to separate the prompt example
                 from the target text.
+                NOTE: This is assumed to be some form of whitespace-only separation,
+                    e.g. "\n\n", "\t", "  ", etc. Otherwise, you should update
+                    the Task's `promptsource` template with the appropriate
+                    separator(s).
                 Example:
                     Q: Where is the Eiffel Tower located? A:{text_target_separator}Paris
         """
+        assert (
+            text_target_separator.isspace()
+        ), f"`text_target_separator` must be whitespace only. Got: `{text_target_separator}`"
         super().__init__(data_dir, cache_dir, download_mode)
         self.prompt_template = prompt_template
         self.save_examples = save_examples


### PR DESCRIPTION
* This PR removes the custom `text_target_separator` leading whitespace from Seq2SeqLM labels during log-likelihood scoring, as the contexts and continuations are never concatenated into single (decoder) inputs.

* __Related Issue__: #135 