### PR TITLE
Added special few-shot examples for DiaBLa and Flores

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -108,6 +108,7 @@ TASK_REGISTRY = {
     "crd3": crd3.CRD3,
     # DiaBLa
     "diabla": diabla.DiaBLa,
+    "diabla_1_shot_context": diabla.DiaBLa_1_shot_context,
     # XQuAD
     "xquad_en": xquad.XQuADEnglish,
     "xquad_ar": xquad.XQuADArabic,
@@ -115,6 +116,10 @@ TASK_REGISTRY = {
     "piaf": piaf.PIAF,
     # Flores 101 (MT)
     "flores_101_mt": flores_101.Flores101MT,
+    "flores_101_mt_fewshot_fr2en": flores_101.Flores101MT_fewshot_fr2en,
+    "flores_101_mt_fewshot_hi2en": flores_101.Flores101MT_fewshot_hi2en,
+    "flores_101_mt_fewshot_fr2ar": flores_101.Flores101MT_fewshot_fr2ar,
+   "flores_101_mt_fewshot_wmt_fr2en": flores_101.Flores101MT_fewshot_wmt_fr2en,
     # Flores101 (Perplexity)
     "flores_101_ppl": flores_101.Flores101Perplexity,
     # GEM/WebNLG

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -119,7 +119,7 @@ TASK_REGISTRY = {
     "flores_101_mt_fewshot_fr2en": flores_101.Flores101MT_fewshot_fr2en,
     "flores_101_mt_fewshot_hi2en": flores_101.Flores101MT_fewshot_hi2en,
     "flores_101_mt_fewshot_fr2ar": flores_101.Flores101MT_fewshot_fr2ar,
-   "flores_101_mt_fewshot_wmt_fr2en": flores_101.Flores101MT_fewshot_wmt_fr2en,
+    "flores_101_mt_fewshot_wmt_fr2en": flores_101.Flores101MT_fewshot_wmt_fr2en,
     # Flores101 (Perplexity)
     "flores_101_ppl": flores_101.Flores101Perplexity,
     # GEM/WebNLG

--- a/lm_eval/tasks/diabla.py
+++ b/lm_eval/tasks/diabla.py
@@ -79,7 +79,7 @@ class DiaBLa_1_shot_context(PromptSourceTask):
 
     DATASET_PATH = "rbawden/DiaBLa"
     DATASET_NAME = None
-    
+
     def has_training_docs(self):
         return False
 
@@ -132,10 +132,12 @@ class DiaBLa_1_shot_context(PromptSourceTask):
         old_jinja = self.shot_prompt_template.jinja
         preamble = '{% set src_sent = ""%}'
         preamble += '{% set trg_sent = "" %}'
-        preamble += '{% if dialogue_history|length > 0 %}{% if utterance_meta.lang == dialogue_history[-1].utterance_meta.lang %}{% set src_sent = dialogue_history[-1].orig %}{% set trg_sent = dialogue_history[-1].ref %}{% else %}{% set src_sent = dialogue_history[-1].ref %}{% set trg_sent = dialogue_history[-1].orig %}{% endif %}{% endif %}'
-        self.shot_prompt_template.jinja = preamble +  old_jinja.replace('{{ orig }}', '{{ src_sent }}').replace('{{ ref }}', '{{ trg_sent }}')
+        preamble += "{% if dialogue_history|length > 0 %}{% if utterance_meta.lang == dialogue_history[-1].utterance_meta.lang %}{% set src_sent = dialogue_history[-1].orig %}{% set trg_sent = dialogue_history[-1].ref %}{% else %}{% set src_sent = dialogue_history[-1].ref %}{% set trg_sent = dialogue_history[-1].orig %}{% endif %}{% endif %}"
+        self.shot_prompt_template.jinja = preamble + old_jinja.replace(
+            "{{ orig }}", "{{ src_sent }}"
+        ).replace("{{ ref }}", "{{ trg_sent }}")
         return self.shot_prompt_template
-        
+
     def fewshot_examples(
         self,
         docs: datasets.Dataset,
@@ -181,7 +183,6 @@ class DiaBLa_1_shot_context(PromptSourceTask):
             rng is not None
         ), "A `numpy.random.Generator` argument must be provided to `rng`"
 
-        
         if num_fewshot == 0:
             labeled_examples = ""
             fewshot_idx, fewshot_target_idx, fewshot_src = ([], [], None)
@@ -209,7 +210,6 @@ class DiaBLa_1_shot_context(PromptSourceTask):
             # Leave an extra `example_separator` right before the prompt.
             labeled_examples += self.example_separator
 
-            
         prompt = self.doc_to_text(doc)
         ctx = labeled_examples + prompt
         logging_info = {

--- a/lm_eval/tasks/diabla.py
+++ b/lm_eval/tasks/diabla.py
@@ -19,6 +19,10 @@ versions and reference translations produced a posteriori
 Homepage: http://almanach.inria.fr/software_and_resources/custom/DiaBLa-en.html
 """
 from lm_eval.api.task import PromptSourceTask
+from typing import List, Tuple, Union, Optional
+import datasets
+import copy
+import numpy as np
 
 
 _CITATION = """@article{bawden_DiaBLa:-A-Corpus-of_2021,
@@ -69,3 +73,150 @@ class DiaBLa(PromptSourceTask):
         if len(self.doc_to_target(doc)) == 0 or self.doc_to_target(doc)[0] == "":
             return True
         return False
+
+
+class DiaBLa_1_shot_context(PromptSourceTask):
+
+    DATASET_PATH = "rbawden/DiaBLa"
+    DATASET_NAME = None
+    
+    def has_training_docs(self):
+        return False
+
+    def has_validation_docs(self):
+        return False
+
+    def has_test_docs(self):
+        return True
+
+    def training_docs(self):
+        if self.has_training_docs():
+            return self.dataset["train"]
+
+    def validation_docs(self):
+        if self.has_validation_docs():
+            return self.dataset["validation"]
+
+    def test_docs(self):
+        if self.has_test_docs():
+            return self.dataset["test"]
+
+    def max_generation_length(self):
+        return 512
+
+    def invalid_doc_for_prompt(self, doc) -> bool:
+        if len(self.doc_to_target(doc)) == 0 or self.doc_to_target(doc)[0] == "":
+            return True
+        return False
+
+    def doc_to_shot_text(self, doc: dict) -> str:
+        text, _ = self.shot_prompt_template.apply(doc)
+        return text
+
+    def doc_to_shot_target(self, doc: dict) -> List[str]:
+        _, target = self.shot_prompt_template.apply(doc)
+        return target
+
+    def fewshot_docs(self) -> datasets.Dataset:
+        """
+        Returns the `dataset` split that the few-shot examples should be sample
+        from. This prioritizes the `train_docs` split as the few-shot example
+        source, then `validation_docs`, and lastly `test_docs`.
+        """
+        return self.test_docs()
+
+    # heuristically hack the current template to replace the attributes 'orig' and 'ref' by
+    # the original and reference sentences of the previous sentence (if available)
+    def get_fewshot_template(self):
+        self.shot_prompt_template = copy.deepcopy(self.prompt_template)
+        old_jinja = self.shot_prompt_template.jinja
+        preamble = '{% set src_sent = ""%}'
+        preamble += '{% set trg_sent = "" %}'
+        preamble += '{% if dialogue_history|length > 0 %}{% if utterance_meta.lang == dialogue_history[-1].utterance_meta.lang %}{% set src_sent = dialogue_history[-1].orig %}{% set trg_sent = dialogue_history[-1].ref %}{% else %}{% set src_sent = dialogue_history[-1].ref %}{% set trg_sent = dialogue_history[-1].orig %}{% endif %}{% endif %}'
+        self.shot_prompt_template.jinja = preamble +  old_jinja.replace('{{ orig }}', '{{ src_sent }}').replace('{{ ref }}', '{{ trg_sent }}')
+        return self.shot_prompt_template
+        
+    def fewshot_examples(
+        self,
+        docs: datasets.Dataset,
+        k: int,
+        rng: np.random.Generator,
+        prompt: dict = None,
+    ) -> Tuple[List[dict], List[int]]:
+        """Returns `k` random examples from the set of documents in `docs`.
+
+        :param docs: datasets.Dataset
+            The dataset of documents to sample few-shot examples from.
+        :param k: int
+            The number of few-shot examples.
+        :param rng: np.random.Generator
+            The pseudo-random number generator used to randomly sample examples.
+        :param prompt: Optional[dict]
+            The prompt document. Specify this to ensure the prompt is not in
+            the set of few-shot examples.
+        """
+        # hack the hack to the be used so that it uses other attributes
+        self.get_fewshot_template()
+        return [prompt], 0
+
+    def fewshot_context(
+        self, doc: dict, num_fewshot: int, rng: Optional[np.random.Generator]
+    ) -> Tuple[str, dict]:
+        """Returns a few-shot context string made up of `num_fewshot` number of
+        labeled examples, and an appended prompt example without labeling.
+
+        :param doc: dict
+            The document as returned from training_docs, validation_docs, or test_docs.
+        :param num_fewshot: int
+            The number of fewshot examples to provide in the returned context string.
+        :param rng: numpy.random.Generator
+            The pseudo-random number generator used to randomly sample few-shot examples.
+        :returns: Tuple[str, dict]
+            ctx: str
+                The fewshot context.
+            logging_info: dict
+                A `dict` of logging info that can be used to identify few-shot sources.
+        """
+        assert (
+            rng is not None
+        ), "A `numpy.random.Generator` argument must be provided to `rng`"
+
+        
+        if num_fewshot == 0:
+            labeled_examples = ""
+            fewshot_idx, fewshot_target_idx, fewshot_src = ([], [], None)
+        else:
+            # Construct few-shot labeled examples.
+            fewshot_docs = self.fewshot_docs()
+            fewshot_src = str(fewshot_docs.split)
+            fewshot_examples, fewshot_idx = self.fewshot_examples(
+                fewshot_docs, k=num_fewshot, rng=rng, prompt=doc
+            )
+            labeled_examples_list = []
+            fewshot_target_idx = []
+            for fewshot_example in fewshot_examples:
+                # format the example, but use the previous context of the example
+                text = self.doc_to_shot_text(fewshot_example)
+                targets = self.doc_to_shot_target(fewshot_example)
+                # Choose 1 random target from multi-reference targets.
+                target_idx = int(rng.integers(0, len(targets)))
+                target = targets[target_idx].strip()
+                labeled_examples_list.append(
+                    self.format_example(text, target, self.text_target_separator)
+                )
+                fewshot_target_idx.append(target_idx)
+            labeled_examples = self.example_separator.join(labeled_examples_list)
+            # Leave an extra `example_separator` right before the prompt.
+            labeled_examples += self.example_separator
+
+            
+        prompt = self.doc_to_text(doc)
+        ctx = labeled_examples + prompt
+        logging_info = {
+            "fewshot_idx": fewshot_idx,
+            "fewshot_target_idx": fewshot_target_idx,
+            "fewshot_source": fewshot_src,
+            "fewshot_num": num_fewshot,
+            "ctx": ctx,
+        }
+        return ctx, logging_info

--- a/lm_eval/tasks/diabla.py
+++ b/lm_eval/tasks/diabla.py
@@ -76,7 +76,13 @@ class DiaBLa(PromptSourceTask):
 
 
 class DiaBLa_1_shot_context(PromptSourceTask):
-
+    """
+    This task is identical to the DiaBLa task, but in the 1-shot setting takes the
+    1-shot example from the previous sentence in the dialogue if this is available
+    (source sentence and MT output, in the same language direction as the direction
+    of the current example). N.B. this task is not currently designed for more than 
+    1-shot.
+    """
     DATASET_PATH = "rbawden/DiaBLa"
     DATASET_NAME = None
 

--- a/lm_eval/tasks/diabla.py
+++ b/lm_eval/tasks/diabla.py
@@ -80,9 +80,10 @@ class DiaBLa_1_shot_context(PromptSourceTask):
     This task is identical to the DiaBLa task, but in the 1-shot setting takes the
     1-shot example from the previous sentence in the dialogue if this is available
     (source sentence and MT output, in the same language direction as the direction
-    of the current example). N.B. this task is not currently designed for more than 
+    of the current example). N.B. this task is not currently designed for more than
     1-shot.
     """
+
     DATASET_PATH = "rbawden/DiaBLa"
     DATASET_NAME = None
 

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -114,39 +114,46 @@ class Flores101MT_fewshot_wmt_fr2en(Flores101MT):
         self.text_target_separator = text_target_separator
         self.cache_dir = cache_dir
         self.download_mode = download_mode
-    
+
     def fewshot_docs(self) -> datasets.Dataset:
         """Returns a wmt dataset split"""
-        return datasets.load_dataset('wmt14', 'fr-en',
-            cache_dir=self.cache_dir, download_mode=self.download_mode,
-        )['validation']
+        return datasets.load_dataset(
+            "wmt14",
+            "fr-en",
+            cache_dir=self.cache_dir,
+            download_mode=self.download_mode,
+        )["validation"]
 
-    
+
 class Flores101MT_fewshot_fr2en(Flores101MT):
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"
 
     def fewshot_values(self):
-        return 'French', 'English', '{{ sentence_fra }}', '{{ sentence_eng }}'
-        
+        return "French", "English", "{{ sentence_fra }}", "{{ sentence_eng }}"
+
     # heuristically hack the prompt template used to create few-shot examples
     def get_fewshot_template(self):
         self.shot_prompt_template = copy.deepcopy(self.prompt_template)
 
         # get things to replace in the prompt
-        src_lang, trg_lang = self.prompt_template.name.split('-')[-2:]
-        src_sent, trg_sent = re.findall('{{ .+? }}', self.prompt_template.jinja)
+        src_lang, trg_lang = self.prompt_template.name.split("-")[-2:]
+        src_sent, trg_sent = re.findall("{{ .+? }}", self.prompt_template.jinja)
         # new attributes to drop in as replacement
         new_src_lang, new_trg_lang, new_src_sent, new_trg_sent = self.fewshot_values()
         # create new prompt
         assert len(re.findall(src_lang, self.shot_prompt_template.jinja)) == 1
         assert len(re.findall(trg_lang, self.shot_prompt_template.jinja)) == 1
-        for old_text, new_text in [(src_lang, new_src_lang),
-                                   (trg_lang, new_trg_lang),
-                                   (src_sent, new_src_sent),
-                                   (trg_sent, new_src_sent)]:
-            self.shot_prompt_template.jinja = self.shot_prompt_template.jinja.replace(old_text, new_text)
+        for old_text, new_text in [
+            (src_lang, new_src_lang),
+            (trg_lang, new_trg_lang),
+            (src_sent, new_src_sent),
+            (trg_sent, new_src_sent),
+        ]:
+            self.shot_prompt_template.jinja = self.shot_prompt_template.jinja.replace(
+                old_text, new_text
+            )
         return self.shot_prompt_template
 
     def fewshot_context(
@@ -172,7 +179,7 @@ class Flores101MT_fewshot_fr2en(Flores101MT):
         ), "A `numpy.random.Generator` argument must be provided to `rng`"
 
         self.get_fewshot_template()
-        
+
         if num_fewshot == 0:
             labeled_examples = ""
             fewshot_idx, fewshot_target_idx, fewshot_src = ([], [], None)
@@ -200,7 +207,6 @@ class Flores101MT_fewshot_fr2en(Flores101MT):
             # Leave an extra `example_separator` right before the prompt.
             labeled_examples += self.example_separator
 
-            
         prompt = self.doc_to_text(doc)
         ctx = labeled_examples + prompt
         logging_info = {
@@ -220,13 +226,15 @@ class Flores101MT_fewshot_fr2en(Flores101MT):
         _, target = self.shot_prompt_template.apply(doc)
         return target
 
+
 class Flores101MT_fewshot_hi2en(Flores101MT_fewshot_fr2en):
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"
 
     def fewshot_values(self):
-        return 'Hindi', 'English', '{{ sentence_hin }}', '{{ sentence_eng }}'
+        return "Hindi", "English", "{{ sentence_hin }}", "{{ sentence_eng }}"
+
 
 class Flores101MT_fewshot_fr2ar(Flores101MT_fewshot_fr2en):
     VERSION = 0
@@ -234,8 +242,9 @@ class Flores101MT_fewshot_fr2ar(Flores101MT_fewshot_fr2en):
     DATASET_NAME = "all"
 
     def fewshot_values(self):
-        return 'French', 'Arabic', '{{ sentence_fra }}', '{{ sentence_ara }}'
-    
+        return "French", "Arabic", "{{ sentence_fra }}", "{{ sentence_ara }}"
+
+
 class Flores101Perplexity(PerplexityTask):
     """Computes the perplexity for a specific language translation of Flores-101.
 

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -11,9 +11,13 @@ FLORES-101 is a Many-to-Many multilingual translation benchmark dataset for 101 
 
 Github: https://github.com/facebookresearch/flores
 """
-from typing import List
+from lm_eval.api.task import PromptSourceTask, PerplexityTask
+from typing import List, Tuple, Union, Optional
+import datasets
+import copy, re
+import numpy as np
+import promptsource.templates
 from lm_eval import tasks
-from lm_eval.api.task import PerplexityTask, PromptSourceTask
 
 
 _CITATION = """
@@ -63,6 +67,175 @@ class Flores101MT(PromptSourceTask):
         return 512
 
 
+class Flores101MT_fewshot_wmt_fr2en(Flores101MT):
+    VERSION = 0
+    DATASET_PATH = "gsarti/flores_101"
+    DATASET_NAME = "all"
+
+    def __init__(
+        self,
+        data_dir: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        download_mode: Optional[str] = None,
+        prompt_template: Optional[promptsource.templates.Template] = None,
+        example_separator: Optional[str] = "\n###\n",
+        text_target_separator: Optional[str] = " ",
+        save_examples: Optional[bool] = True,
+    ):
+        """
+        Args:
+            save_examples (bool, optional, defaults to True):
+                Whether to save each example and corresponding model predictions
+                to an output `dict`.
+            > Few-shot prompting args
+            example_separator (str, optional, defaults to '\n###\n'):
+                The string that will be used to separate the few-shot examples
+                from the prompt example.
+                Default: '\n###\n'
+                    See Webson & Pavlick (2022) https://arxiv.org/pdf/2109.01247.pdf
+                    for justification of this separator.
+            text_target_separator (str, optional, defaults to ' '):
+                The string that will be used to separate the prompt example
+                from the target text.
+                NOTE: This is assumed to be some form of whitespace-only separation,
+                    e.g. "\n\n", "\t", "  ", etc. Otherwise, you should update
+                    the Task's `promptsource` template with the appropriate
+                    separator(s).
+                Example:
+                    Q: Where is the Eiffel Tower located? A:{text_target_separator}Paris
+        """
+        assert (
+            text_target_separator.isspace()
+        ), f"`text_target_separator` must be whitespace only. Got: `{text_target_separator}`"
+        super().__init__(data_dir, cache_dir, download_mode)
+        self.prompt_template = prompt_template
+        self.save_examples = save_examples
+        self.example_separator = example_separator
+        self.text_target_separator = text_target_separator
+        self.cache_dir = cache_dir
+        self.download_mode = download_mode
+    
+    def fewshot_docs(self) -> datasets.Dataset:
+        """Returns a wmt dataset split"""
+        return datasets.load_dataset('wmt14', 'fr-en',
+            cache_dir=self.cache_dir, download_mode=self.download_mode,
+        )['validation']
+
+    
+class Flores101MT_fewshot_fr2en(Flores101MT):
+    VERSION = 0
+    DATASET_PATH = "gsarti/flores_101"
+    DATASET_NAME = "all"
+
+    def fewshot_values(self):
+        return 'French', 'English', '{{ sentence_fra }}', '{{ sentence_eng }}'
+        
+    # heuristically hack the prompt template used to create few-shot examples
+    def get_fewshot_template(self):
+        self.shot_prompt_template = copy.deepcopy(self.prompt_template)
+
+        # get things to replace in the prompt
+        src_lang, trg_lang = self.prompt_template.name.split('-')[-2:]
+        src_sent, trg_sent = re.findall('{{ .+? }}', self.prompt_template.jinja)
+        # new attributes to drop in as replacement
+        new_src_lang, new_trg_lang, new_src_sent, new_trg_sent = self.fewshot_values()
+        # create new prompt
+        assert len(re.findall(src_lang, self.shot_prompt_template.jinja)) == 1
+        assert len(re.findall(trg_lang, self.shot_prompt_template.jinja)) == 1
+        for old_text, new_text in [(src_lang, new_src_lang),
+                                   (trg_lang, new_trg_lang),
+                                   (src_sent, new_src_sent),
+                                   (trg_sent, new_src_sent)]:
+            self.shot_prompt_template.jinja = self.shot_prompt_template.jinja.replace(old_text, new_text)
+        return self.shot_prompt_template
+
+    def fewshot_context(
+        self, doc: dict, num_fewshot: int, rng: Optional[np.random.Generator]
+    ) -> Tuple[str, dict]:
+        """Returns a few-shot context string made up of `num_fewshot` number of
+        labeled examples, and an appended prompt example without labeling.
+
+        :param doc: dict
+            The document as returned from training_docs, validation_docs, or test_docs.
+        :param num_fewshot: int
+            The number of fewshot examples to provide in the returned context string.
+        :param rng: numpy.random.Generator
+            The pseudo-random number generator used to randomly sample few-shot examples.
+        :returns: Tuple[str, dict]
+            ctx: str
+                The fewshot context.
+            logging_info: dict
+                A `dict` of logging info that can be used to identify few-shot sources.
+        """
+        assert (
+            rng is not None
+        ), "A `numpy.random.Generator` argument must be provided to `rng`"
+
+        self.get_fewshot_template()
+        
+        if num_fewshot == 0:
+            labeled_examples = ""
+            fewshot_idx, fewshot_target_idx, fewshot_src = ([], [], None)
+        else:
+            # Construct few-shot labeled examples.
+            fewshot_docs = self.fewshot_docs()
+            fewshot_src = str(fewshot_docs.split)
+            fewshot_examples, fewshot_idx = self.fewshot_examples(
+                fewshot_docs, k=num_fewshot, rng=rng, prompt=doc
+            )
+            labeled_examples_list = []
+            fewshot_target_idx = []
+            for fewshot_example in fewshot_examples:
+                # format the example, but use the previous context of the example
+                text = self.doc_to_shot_text(fewshot_example)
+                targets = self.doc_to_shot_target(fewshot_example)
+                # Choose 1 random target from multi-reference targets.
+                target_idx = int(rng.integers(0, len(targets)))
+                target = targets[target_idx].strip()
+                labeled_examples_list.append(
+                    self.format_example(text, target, self.text_target_separator)
+                )
+                fewshot_target_idx.append(target_idx)
+            labeled_examples = self.example_separator.join(labeled_examples_list)
+            # Leave an extra `example_separator` right before the prompt.
+            labeled_examples += self.example_separator
+
+            
+        prompt = self.doc_to_text(doc)
+        ctx = labeled_examples + prompt
+        logging_info = {
+            "fewshot_idx": fewshot_idx,
+            "fewshot_target_idx": fewshot_target_idx,
+            "fewshot_source": fewshot_src,
+            "fewshot_num": num_fewshot,
+            "ctx": ctx,
+        }
+        return ctx, logging_info
+
+    def doc_to_shot_text(self, doc: dict) -> str:
+        text, _ = self.shot_prompt_template.apply(doc)
+        return text
+
+    def doc_to_shot_target(self, doc: dict) -> List[str]:
+        _, target = self.shot_prompt_template.apply(doc)
+        return target
+
+class Flores101MT_fewshot_hi2en(Flores101MT_fewshot_fr2en):
+    VERSION = 0
+    DATASET_PATH = "gsarti/flores_101"
+    DATASET_NAME = "all"
+
+    def fewshot_values(self):
+        return 'Hindi', 'English', '{{ sentence_hin }}', '{{ sentence_eng }}'
+
+class Flores101MT_fewshot_fr2ar(Flores101MT_fewshot_fr2en):
+    VERSION = 0
+    DATASET_PATH = "gsarti/flores_101"
+    DATASET_NAME = "all"
+
+    def fewshot_values(self):
+        return 'French', 'Arabic', '{{ sentence_fra }}', '{{ sentence_ara }}'
+    
 class Flores101Perplexity(PerplexityTask):
     """Computes the perplexity for a specific language translation of Flores-101.
 

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -14,7 +14,8 @@ Github: https://github.com/facebookresearch/flores
 from lm_eval.api.task import PromptSourceTask, PerplexityTask
 from typing import List, Tuple, Union, Optional
 import datasets
-import copy, re
+import copy
+import re
 import numpy as np
 import promptsource.templates
 from lm_eval import tasks

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -74,6 +74,7 @@ class Flores101MT_fewshot_wmt_fr2en(Flores101MT):
     where few-shot examples are created using examples from the WMT14 French-to-English
     development set, whatever the language specified in the prompt.
     """
+
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"
@@ -137,6 +138,7 @@ class Flores101MT_fewshot_fr2en(Flores101MT):
     where few-shot examples are created using French as the source language and English
     as the target language, whatever the language specified in the prompt.
     """
+
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"
@@ -244,6 +246,7 @@ class Flores101MT_fewshot_hi2en(Flores101MT_fewshot_fr2en):
     where few-shot examples are created using Hindi as the source language and English
     as the target language, whatever the language specified in the prompt.
     """
+
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"
@@ -258,6 +261,7 @@ class Flores101MT_fewshot_fr2ar(Flores101MT_fewshot_fr2en):
     where few-shot examples are created using French as the source language and Arabic
     as the target language, whatever the language specified in the prompt.
     """
+
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -69,6 +69,11 @@ class Flores101MT(PromptSourceTask):
 
 
 class Flores101MT_fewshot_wmt_fr2en(Flores101MT):
+    """
+    This task is Identical to the Flores101MT task, except in the few-shot setting
+    where few-shot examples are created using examples from the WMT14 French-to-English
+    development set, whatever the language specified in the prompt.
+    """
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"
@@ -127,6 +132,11 @@ class Flores101MT_fewshot_wmt_fr2en(Flores101MT):
 
 
 class Flores101MT_fewshot_fr2en(Flores101MT):
+    """
+    This task is Identical to the Flores101MT task, except in the few-shot setting
+    where few-shot examples are created using French as the source language and English
+    as the target language, whatever the language specified in the prompt.
+    """
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"
@@ -229,6 +239,11 @@ class Flores101MT_fewshot_fr2en(Flores101MT):
 
 
 class Flores101MT_fewshot_hi2en(Flores101MT_fewshot_fr2en):
+    """
+    This task is Identical to the Flores101MT task, except in the few-shot setting
+    where few-shot examples are created using Hindi as the source language and English
+    as the target language, whatever the language specified in the prompt.
+    """
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"
@@ -238,6 +253,11 @@ class Flores101MT_fewshot_hi2en(Flores101MT_fewshot_fr2en):
 
 
 class Flores101MT_fewshot_fr2ar(Flores101MT_fewshot_fr2en):
+    """
+    This task is Identical to the Flores101MT task, except in the few-shot setting
+    where few-shot examples are created using French as the source language and Arabic
+    as the target language, whatever the language specified in the prompt.
+    """
     VERSION = 0
     DATASET_PATH = "gsarti/flores_101"
     DATASET_NAME = "all"


### PR DESCRIPTION
Added new tasks to be used in the fewshot setting: 
- DiaBLa_1_shot_context: (only 1-shot), takes the previous sentence as context (if available)
- flores_101_mt_fewshot_fr2en: takes fr2en examples for fewshot
- flores_101_mt_fewshot_hi2en: takes hi2en examples for fewshot
- flores_101_mt_fewshot_fr2ar: takes fr2ar examples for fewshot
- flores_101_mt_fewshot_wmt_fr2en: takes fr2en examples from the wmt dev set for fewshot
