### PR TITLE
[fix] Skip `doc_id` in few-shot prompt comparison

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -355,7 +355,12 @@ class PromptSourceTask(Task):
         for idx in random_indices:
             if i >= k:  # Break when we have enough examples.
                 break
-            if self.invalid_doc_for_prompt(docs[idx]) or docs[idx] == prompt:
+            is_same_prompt = prompt is not None and all(
+                # Skips the `doc_id` key assigned to `prompt`s during eval pre-processing.
+                docs[idx][k] == prompt[k]
+                for k in docs[idx].keys()
+            )
+            if self.invalid_doc_for_prompt(docs[idx]) or is_same_prompt:
                 continue
             fewshot_examples.append(docs[idx])
             fewshot_idx.append(int(idx))


### PR DESCRIPTION
This PR fixes a bug in which, under rare circumstances, few-shot examples could contain the same example as the prompt to be evaluated.  The comparison used to prevent such cases: `if self.invalid_doc_for_prompt(docs[idx]) or docs[idx] == prompt` ([this](https://github.com/bigscience-workshop/lm-evaluation-harness/blob/00bb6f162b10049f2a6b44764dec1fb0a797762c/lm_eval/api/task.py#L358) line) is incorrect because every `prompt` contains a `doc_id` key from evaluation pre-processing (see [this](https://github.com/bigscience-workshop/lm-evaluation-harness/blob/00bb6f162b10049f2a6b44764dec1fb0a797762c/lm_eval/evaluator.py#L166) line) that is not present in the few-shot `docs` - thus invalidating the check.

__NOTE__: This only occurs when the [`fewshot_docs`](https://github.com/bigscience-workshop/lm-evaluation-harness/blob/00bb6f162b10049f2a6b44764dec1fb0a797762c/lm_eval/api/task.py#L288) and [`evaluation_docs`](https://github.com/bigscience-workshop/lm-evaluation-harness/blob/00bb6f162b10049f2a6b44764dec1fb0a797762c/lm_eval/api/task.py#L279) use the same dataset split.

Discovered by: @rbawden