### PR TITLE
Add all available doc splits to `flores_101`

### DIFF
--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -297,11 +297,15 @@ class Flores101Perplexity(PerplexityTask):
         return True
 
     def has_test_docs(self):
-        return False
+        return True
 
     def validation_docs(self):
         if self.has_validation_docs():
             return self.dataset["dev"]
+
+    def test_docs(self):
+        if self.has_test_docs():
+            return self.dataset["devtest"]
 
     def doc_to_target(self, doc):
         """This is a null prompt task. We need to get the target from the doc."""

--- a/lm_eval/tasks/flores_101.py
+++ b/lm_eval/tasks/flores_101.py
@@ -55,10 +55,14 @@ class Flores101MT(PromptSourceTask):
         return False
 
     def has_validation_docs(self):
-        return False
+        return True
 
     def has_test_docs(self):
         return True
+
+    def validation_docs(self):
+        if self.has_validation_docs():
+            return self.dataset["dev"]
 
     def test_docs(self):
         if self.has_test_docs():


### PR DESCRIPTION
This PR adds missing `dev` and `devtest` data splits to the `flores_101` tasks.