### PR TITLE
[feature] Add task constructor arg support to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ optional arguments:
   --task_name TASK_NAME
                         Name of the task to use as found in the lm_eval registry. See: `lm_eval.list_tasks()`
   --task_args TASK_ARGS
-                        Optional task constructor args that you'd pass into a task class of kind `--task_name`. These must be comma-separated keyword args, e.g. `key1=value1,key2=value2`, with no spaces
+                        Optional task constructor args that you'd pass into a task class of kind " `--task_name`. These must be comma-separated keyword args, e.g. `key1=value1,key2=value2`, with no spaces.
+                        WARNING: To avoid parsing errors, ensure your strings are quoted. For example, example_separator='\n+++\n'. Separators must not contain commas.
   --template_names TEMPLATE_NAMES
                         Comma-separated list of template names for the specified task. Example:
                         `> python main.py ... --task_name rte --template_names imply,mean`

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ optional arguments:
   --task_name TASK_NAME
                         Name of the task to use as found in the lm_eval registry. See: `lm_eval.list_tasks()`
   --task_args TASK_ARGS
-                        Optional constructor args that you'd pass into a task class of kind `--task_name`. These must be comma-separated keyword args, e.g. `key1=value1,key2=value2`, with no spaces
+                        Optional task constructor args that you'd pass into a task class of kind `--task_name`. These must be comma-separated keyword args, e.g. `key1=value1,key2=value2`, with no spaces
   --template_names TEMPLATE_NAMES
                         Comma-separated list of template names for the specified task. Example:
                         `> python main.py ... --task_name rte --template_names imply,mean`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ optional arguments:
                         be comma-separated keyword args, e.g. `key1=value1,key2=value2`, with no spaces
   --task_name TASK_NAME
                         Name of the task to use as found in the lm_eval registry. See: `lm_eval.list_tasks()`
+  --task_args TASK_ARGS
+                        Optional constructor args that you'd pass into a task class of kind `--task_name`. These must be comma-separated keyword args, e.g. `key1=value1,key2=value2`, with no spaces
   --template_names TEMPLATE_NAMES
                         Comma-separated list of template names for the specified task. Example:
                         `> python main.py ... --task_name rte --template_names imply,mean`

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -254,9 +254,14 @@ class PromptSourceTask(Task):
                 Example:
                     Q: Where is the Eiffel Tower located? A:{text_target_separator}Paris
         """
+        assert isinstance(save_examples, bool), "`save_examples` must be a bool."
+        assert isinstance(example_separator, str) and isinstance(
+            text_target_separator, str
+        ), "Separator args must be strings."
         assert (
             text_target_separator.isspace()
         ), f"`text_target_separator` must be whitespace only. Got: `{text_target_separator}`"
+
         super().__init__(data_dir, cache_dir, download_mode)
         self.prompt_template = prompt_template
         self.save_examples = save_examples

--- a/lm_eval/api/utils.py
+++ b/lm_eval/api/utils.py
@@ -287,13 +287,15 @@ def parse_cli_args_string(args: str) -> dict:
     """Parses a string in the following format to a kwargs dictionary.
     "args1=val1,arg2=val2"
     """
-    args = args.strip()
+    # Remove leading whitespace but not trailing in case a `val` contains necessary whitespace.
+    args = args.lstrip()
     if not args:
         return {}
     arg_list = args.split(",")
     args_dict = {}
     for arg in arg_list:
-        k, v = arg.split("=")
+        # Split on the first `=` to allow for `=`s in `val`.
+        k, v = arg.split("=", 1)
         args_dict[k] = str_to_builtin_type(v)
     return args_dict
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -100,6 +100,7 @@ def cli_evaluate(
     results["config"] = {
         "model": model_api_name,
         "model_args": model_args,
+        "task_args": task_args,
         "num_fewshot": num_fewshot,
         "batch_size": batch_size,
         "device": device,

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -51,6 +51,7 @@ def cli_evaluate(
         task_args (str):
             String arguments for the task. See:
                 `lm_eval.api.task.get_task_list_from_args_string`
+            WARNING: To avoid parse errors, separators must not contain commas.
         template_names (List[str]):
             List of template names for the specified `task_name` to evaluate
             under.

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -25,6 +25,7 @@ def cli_evaluate(
     model_api_name: str,
     model_args: str,
     task_name: str,
+    task_args: str,
     template_names: List[str],
     num_fewshot: Optional[int] = 0,
     batch_size: Optional[int] = None,
@@ -47,11 +48,17 @@ def cli_evaluate(
                 `lm_eval.api.model.get_model_from_args_string`
         task_name (str):
             The task name of the task to evaluate the model on.
+        task_args (str):
+            String arguments for the task. See:
+                `lm_eval.api.task.get_task_list_from_args_string`
         template_names (List[str]):
             List of template names for the specified `task_name` to evaluate
             under.
         num_fewshot (int, optional, defaults to 0):
             Number of examples in few-shot context.
+        example_separator (str, optional, defaults to None):
+            The string that will be used to separate the few-shot examples
+            from the prompt example.
         batch_size (int, optional, defaults to None):
             Batch size to use for model evaluation.
         device (str, optional, defaults to None):
@@ -69,7 +76,9 @@ def cli_evaluate(
     Returns:
         Dictionary of results.
     """
-    tasks = lm_eval.tasks.get_task_list(task_name, template_names)
+    tasks = lm_eval.tasks.get_task_list_from_args_string(
+        task_name, template_names, task_args
+    )
     model = lm_eval.models.get_model_from_args_string(
         model_api_name, model_args, {"batch_size": batch_size, "device": device}
     )

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -56,9 +56,6 @@ def cli_evaluate(
             under.
         num_fewshot (int, optional, defaults to 0):
             Number of examples in few-shot context.
-        example_separator (str, optional, defaults to None):
-            The string that will be used to separate the few-shot examples
-            from the prompt example.
         batch_size (int, optional, defaults to None):
             Batch size to use for model evaluation.
         device (str, optional, defaults to None):

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -54,7 +54,7 @@ def get_model_from_args_string(
         model_args: A string of comma-separated key=value pairs that will be passed
             to the model constructor. E.g. "pretrained=gpt2,batch_size=32".
         additional_config: An additional dictionary of key=value pairs that will be
-            passed to the model constructor
+            passed to the model constructor.
 
     Returns:
         A language model instance.

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -295,7 +295,7 @@ def get_task_list_from_args_string(
         template_names: Name of the prompt template from `promptsource` to use
             for this task.
         task_args: A string of comma-separated key=value pairs that will be passed
-            to the task constructor. E.g. "data_dir=./datasets,example_separator='\n\n'"
+            to the task constructor. E.g. "data_dir=./datasets,example_separator=\n\n"
         additional_config: An additional dictionary of key=value pairs that will
             be passed to the task constructor.
 

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -1,8 +1,10 @@
 import logging
-from typing import List, Tuple, Type, Union
+from typing import List, Mapping, Tuple, Type, Optional, Union
 from promptsource.templates import DatasetTemplates
 
 from lm_eval.api.task import Task
+import lm_eval.api.utils
+
 
 from . import anli
 from . import blimp
@@ -278,6 +280,38 @@ def get_templates(task_name: str) -> DatasetTemplates:
     """Returns the `promptsource` `DatasetTemplates` for the specified task name."""
     task_class = _get_task_from_registry(task_name)
     return _get_templates_from_task(task_class)
+
+
+def get_task_list_from_args_string(
+    task_name: str,
+    template_names: List[str],
+    task_args: str,
+    additional_config: Optional[Mapping[str, str]] = None,
+) -> List[Task]:
+    """Returns a list of the same task but with multiple prompt templates, each
+    task instantiated with the given kwargs.
+
+    Args:
+        task_name: Name of the task to use as found in the task registry.
+        template_names: Name of the prompt template from `promptsource` to use
+            for this task.
+        task_args: A string of comma-separated key=value pairs that will be passed
+            to the task constructor. E.g. "data_dir=./datasets,example_separator='\n\n'"
+        additional_config: An additional dictionary of key=value pairs that will
+            be passed to the task constructor.
+
+    Returns:
+        A list of `Task` instances.
+    """
+    kwargs = lm_eval.api.utils.parse_cli_args_string(task_args)
+    assert "prompt_template" not in kwargs, (
+        "Cannot specify a `prompt_template` object in the `task_args` string. "
+        "Only primitive type arguments are allowed."
+    )
+    additional_config = {} if additional_config is None else additional_config
+    additional_args = {k: v for k, v in additional_config.items() if v is not None}
+    kwargs.update(additional_args)
+    return get_task_list(task_name, template_names, **kwargs)
 
 
 # Helper functions

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -2,9 +2,8 @@ import logging
 from typing import List, Mapping, Tuple, Type, Optional, Union
 from promptsource.templates import DatasetTemplates
 
-from lm_eval.api.task import Task
 import lm_eval.api.utils
-
+from lm_eval.api.task import Task
 
 from . import anli
 from . import blimp

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ def parse_args():
     parser.add_argument(
         "--task_args",
         default="",
-        help="Task constructor args that you'd pass into a task class of kind "
+        help="Optional task constructor args that you'd pass into a task class of kind "
         "`--task_name`. These must be comma-separated keyword args, e.g. "
         "`key1=value1,key2=value2`, with no spaces",
     )

--- a/main.py
+++ b/main.py
@@ -32,6 +32,13 @@ def parse_args():
         "in the lm_eval registry. See: `lm_eval.list_tasks()`",
     )
     parser.add_argument(
+        "--task_args",
+        default="",
+        help="Task constructor args that you'd pass into a task class of kind "
+        "`--task_name`. These must be comma-separated keyword args, e.g. "
+        "`key1=value1,key2=value2`, with no spaces",
+    )
+    parser.add_argument(
         "--template_names",
         default="all_templates",
         help="""Comma-separated list of template names for the specified
@@ -167,6 +174,7 @@ def main():
         model_api_name=args.model_api_name,
         model_args=args.model_args,
         task_name=args.task_name,
+        task_args=args.task_args,
         template_names=template_names,
         num_fewshot=args.num_fewshot,
         batch_size=args.batch_size,

--- a/main.py
+++ b/main.py
@@ -34,9 +34,11 @@ def parse_args():
     parser.add_argument(
         "--task_args",
         default="",
-        help="Optional task constructor args that you'd pass into a task class of kind "
-        "`--task_name`. These must be comma-separated keyword args, e.g. "
-        "`key1=value1,key2=value2`, with no spaces",
+        help="""Optional task constructor args that you'd pass into a task class of kind "
+        `--task_name`. These must be comma-separated keyword args, e.g.
+        `key1=value1,key2=value2`, with no spaces.
+        WARNING: To avoid parsing errors, ensure your strings are quoted. For example,
+        example_separator='\\n+++\\n'. Separators must not contain commas.""",
     )
     parser.add_argument(
         "--template_names",

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -147,6 +147,10 @@ def test_arg_string_task_creation():
         "\n\n\n\n",
         # Test empty string separator
         "",
+        # Test misc. symbols in separator
+        "[[[[]]]]",
+        "<<___>>",
+        "(())",
     ]
     TEST_TEXT_TARGET_SEPS = [
         # Test whitespace separators

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -132,3 +132,37 @@ def test_documents_and_requests(task_name: str, task_class: Task):
             # TODO: Mock lm after refactoring evaluator.py to not be a mess
             for req in requests:
                 assert isinstance(req, Request)
+
+
+def test_arg_string_task_creation():
+    arg_string = "text_target_separator=\n\n,example_separator=\t,save_examples=False"
+    task = tasks.get_task_list_from_args_string(
+        "wnli",
+        template_names=["confident"],
+        task_args=arg_string,
+    )[0]
+    assert task.example_separator == "\t"
+    assert task.save_examples is False
+
+    with pytest.raises(AssertionError):
+        # Ensure tasks don't instantiate with invalid args.
+        bad_save_examples_arg_string = "example_separator=\t,save_examples=yes"
+        task = tasks.get_task_list_from_args_string(
+            "wnli",
+            template_names=["confident"],
+            task_args=bad_save_examples_arg_string,
+        )[0]
+
+        bad_example_sep_arg_string = "example_separator=False,save_examples=False"
+        task = tasks.get_task_list_from_args_string(
+            "wnli",
+            template_names=["confident"],
+            task_args=bad_example_sep_arg_string,
+        )[0]
+
+        bad_text_sep_arg_string = "text_target_separator=\n\n"
+        task = tasks.get_task_list_from_args_string(
+            "wnli",
+            template_names=["confident"],
+            task_args=bad_text_sep_arg_string,
+        )[0]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -160,7 +160,7 @@ def test_arg_string_task_creation():
             task_args=bad_example_sep_arg_string,
         )[0]
 
-        bad_text_sep_arg_string = "text_target_separator=\n\n"
+        bad_text_sep_arg_string = "text_target_separator=___"
         task = tasks.get_task_list_from_args_string(
             "wnli",
             template_names=["confident"],

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -136,22 +136,49 @@ def test_documents_and_requests(task_name: str, task_class: Task):
 
 
 def test_arg_string_task_creation():
+    import itertools
+
+    TEST_EXAMPLE_SEPS = [
+        # Test `=` symbol in value string
+        "\n===TEST_SEPARATOR===\n",
+        # Test whitespace only separators
+        " ",
+        " \t\t  ",
+        "\n\n\n\n",
+        # Test empty string separator
+        "",
+    ]
+    TEST_TEXT_TARGET_SEPS = [
+        # Test whitespace separators
+        "   ",
+        " \t ",
+        "\n\n\n",
+    ]
+
+    # Ensure parsing properly handles args.
+    for example_sep, text_target_sep in itertools.product(
+        TEST_EXAMPLE_SEPS, TEST_TEXT_TARGET_SEPS
+    ):
+        test_arg_string = f" save_examples=False,example_separator={example_sep},text_target_separator={text_target_sep}"
+        task = tasks.get_task_list_from_args_string(
+            "wnli",
+            template_names=["confident"],
+            task_args=test_arg_string,
+        )[0]
+
+        assert task.save_examples is False
+        assert task.example_separator == example_sep
+        assert task.text_target_separator == text_target_sep
+
+    # Ensure fewshot context is formatted as expected.
     TEST_EXAMPLE_SEP = "\n===TEST_SEPARATOR===\n"
     TEST_TEXT_TARGET_SEP = "   "
-    TEST_ARG_STRING = f" save_examples=False,example_separator={TEST_EXAMPLE_SEP},text_target_separator={TEST_TEXT_TARGET_SEP}"
-
+    test_arg_string = f" save_examples=False,example_separator={TEST_EXAMPLE_SEP},text_target_separator={TEST_TEXT_TARGET_SEP}"
     task = tasks.get_task_list_from_args_string(
         "wnli",
         template_names=["confident"],
-        task_args=TEST_ARG_STRING,
+        task_args=test_arg_string,
     )[0]
-
-    # Ensure parsing properly handles args.
-    assert task.save_examples is False
-    assert task.example_separator == TEST_EXAMPLE_SEP
-    assert task.text_target_separator == TEST_TEXT_TARGET_SEP
-
-    # Ensure fewshot context is formatted as expected.
     context = task.fewshot_context(
         task.validation_docs()[0],
         num_fewshot=2,


### PR DESCRIPTION
This PR adds support for passing `Task` constructor arguments through the CLI; in the same way model arguments are currently handled via `model_args`. This allows users to customize task instantiation from `main.py` by, say, setting the task's `example_separator` option.

Example:
```bash
python3 main.py \
    --model_api_name "hf-seq2seq" \
    --model_args pretrained=google/t5-small-lm-adapt,add_special_tokens=True \
    --task_name "wsc" \
    --task_args example_separator="\n++++\n",text_target_separator="   " \
    --template_name "the pronoun refers to" \
    --device cpu --batch_size 10 --limit 50 --num_fewshot 1
```

CC: @samsontmr who requested this feature.